### PR TITLE
Fix drop value summary when item price is null

### DIFF
--- a/src/Controllers/FightController.cs
+++ b/src/Controllers/FightController.cs
@@ -116,7 +116,7 @@ public class FightsController(AppDbContext db) : ControllerBase
             .GroupBy(d => d.DropItem.DropType.Type)
             .ToDictionary(
                 g => g.Key,
-                g => g.Sum(d => d.DropItem.Value * d.Quantity)
+                g => g.Sum(d => d.DropItem.Value.GetValueOrDefault() * d.Quantity)
             );
 
         return Ok(new


### PR DESCRIPTION
## Summary
- handle null price values in fight drop summaries

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685008978af48329baa7b295d595639d