### PR TITLE
Add opponent quantity

### DIFF
--- a/src/Controllers/FightController.cs
+++ b/src/Controllers/FightController.cs
@@ -43,8 +43,13 @@ public class FightsController(AppDbContext db) : ControllerBase
             Psycho = fight.Psycho,
             Opponents = string.Join(", ",
                 fight.Opponents
-                    .Select(o => $"{o.OpponentType.Name}({o.OpponentType.Level})")
-                    .Distinct()
+                    .GroupBy(o => new { o.OpponentType.Name, o.OpponentType.Level })
+                    .Select(g =>
+                    {
+                        int qty = g.Sum(o => o.Quantity);
+                        var amount = qty > 1 ? $" ({qty})" : "";
+                        return $"{g.Key.Name}({g.Key.Level}){amount}";
+                    })
             ),
             Drops = string.Join(", ",
                 fight.Drops

--- a/src/Models/OpponentEntity.cs
+++ b/src/Models/OpponentEntity.cs
@@ -8,5 +8,7 @@ namespace BrokenStatsBackend.src.Models
 
         public int OpponentTypeId { get; set; }
         public OpponentTypeEntity OpponentType { get; set; } = null!;
+
+        public int Quantity { get; set; } = 1;
     }
 }

--- a/src/Parser/FightParser.cs
+++ b/src/Parser/FightParser.cs
@@ -72,14 +72,19 @@ namespace BrokenStatsBackend.src.Parser
                 Drops = new List<DropEntity>()
             };
 
-            foreach (var (name, level) in raw.Opponents)
+            foreach (var group in raw.Opponents.GroupBy(o => o))
             {
+                var (name, level) = group.Key;
                 var opponentType = new OpponentTypeEntity
                 {
                     Name = name,
                     Level = level
                 };
-                fight.Opponents.Add(new OpponentEntity { OpponentType = opponentType });
+                fight.Opponents.Add(new OpponentEntity
+                {
+                    OpponentType = opponentType,
+                    Quantity = group.Count()
+                });
             }
 
             string rares = ExtractRares(RemoveTags(raw.RawRaresAndSyngs));


### PR DESCRIPTION
## Summary
- store quantity of each opponent type
- handle quantities when parsing fights
- show quantities in flat fight list

## Testing
- `dotnet build BrokenStatsBackend.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685159b70d348329a914760c6110c9d7