### PR TITLE
Improve summary UI

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,9 +4,11 @@
     <meta charset="UTF-8">
     <title>Broken Stats</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css" rel="stylesheet">
     <style>
         body { padding: 20px; }
+        .summary-row.g-0 { gap: 0; }
+        .summary-box { margin: 1px; border: 1px solid var(--bs-border-color); border-radius: 0.25rem; padding: .5rem; }
+        .summary-inner + .summary-inner { margin-top: 1px; }
     </style>
 </head>
 <body class="bg-dark text-light">
@@ -165,11 +167,11 @@ async function updateSummary(){
     });
     const summary = await res.json();
     const s = document.getElementById('summary');
-    const items = summary.items.map(d=>`<li>${d.name}: ${d.count}</li>`).join('');
-    const drifs = summary.drifs.map(d=>`<li>${d.name}: ${d.count}</li>`).join('');
-    const syner = summary.synergetics.map(d=>`<li>${d.name}: ${d.count}</li>`).join('');
-    const trash = summary.trash.map(d=>`<li>${d.name}: ${d.count}</li>`).join('');
-    const rare = summary.rare.map(d=>`<li>${d.name}: ${d.count}</li>`).join('');
+    const items = summary.items.map(d=>`<li><span class="badge bg-primary me-1">${d.count}</span>${d.name}</li>`).join('');
+    const drifs = summary.drifs.map(d=>`<li><span class="badge bg-primary me-1">${d.count}</span>${d.name}</li>`).join('');
+    const syner = summary.synergetics.map(d=>`<li><span class="badge bg-primary me-1">${d.count}</span>${d.name}</li>`).join('');
+    const trash = summary.trash.map(d=>`<li><span class="badge bg-primary me-1">${d.count}</span>${d.name}</li>`).join('');
+    const rare = summary.rare.map(d=>`<li><span class="badge bg-primary me-1">${d.count}</span>${d.name}</li>`).join('');
     const dropValues = {};
     Object.entries(summary.dropValuesPerType).forEach(([k,v]) => dropValues[k.toLowerCase()] = v);
     const itemsVal = formatNumber(dropValues['item'] || 0);
@@ -178,30 +180,36 @@ async function updateSummary(){
     const trashVal = formatNumber(dropValues['trash'] || 0);
     const rareVal = formatNumber(dropValues['rare'] || 0);
     s.innerHTML = `
-        <div class="row row-cols-2 row-cols-md-3 g-2 text-center">
-            <div class="col border rounded p-2 bg-secondary"><i class="bi bi-star-fill me-1"></i>${formatNumber(summary.totalExp)}</div>
-            <div class="col border rounded p-2 bg-warning text-dark"><i class="bi bi-coin me-1"></i>${formatNumber(summary.totalGold)}</div>
-            <div class="col border rounded p-2 bg-danger"><i class="bi bi-emoji-dizzy me-1"></i>${formatNumber(summary.totalPsycho)}</div>
-            <div class="col border rounded p-2 bg-primary"><i class="bi bi-bar-chart me-1"></i>${formatNumber(summary.fightsCount)}</div>
-            <div class="col border rounded p-2 bg-success"><i class="bi bi-clock me-1"></i>${formatDateTime(summary.sessionStart)}</div>
-            <div class="col border rounded p-2 bg-info text-dark"><i class="bi bi-clock-history me-1"></i>${formatDateTime(summary.sessionEnd)}</div>
+        <div class="row row-cols-2 row-cols-md-3 g-0 text-center summary-row">
+            <div class="col"><div class="summary-box">exp ${formatNumber(summary.totalExp)}</div></div>
+            <div class="col"><div class="summary-box">gold ${formatNumber(summary.totalGold)}</div></div>
+            <div class="col"><div class="summary-box">psycho ${formatNumber(summary.totalPsycho)}</div></div>
+            <div class="col"><div class="summary-box">fights ${formatNumber(summary.fightsCount)}</div></div>
+            <div class="col"><div class="summary-box">start ${formatDateTime(summary.sessionStart)}</div></div>
+            <div class="col"><div class="summary-box">end ${formatDateTime(summary.sessionEnd)}</div></div>
         </div>
-        <div class="row mt-2">
-            <div class="col border rounded p-2 bg-secondary">
+        <div class="row mt-2 g-0 summary-row">
+            <div class="col"><div class="summary-box">
                 <strong>Items <span class="badge bg-light text-dark ms-1">${itemsVal}</span></strong>
                 <ul class="mb-0 list-unstyled">${items}</ul>
-            </div>
-            <div class="col border rounded p-2 bg-info text-dark">
+            </div></div>
+            <div class="col"><div class="summary-box">
                 <strong>Drifs <span class="badge bg-light text-dark ms-1">${drifVal}</span></strong>
                 <ul class="mb-0 list-unstyled">${drifs}</ul>
-            </div>
-            <div class="col border rounded p-2 bg-success text-dark">
-                <strong>Synergetics <span class="badge bg-light text-dark ms-1">${synerVal}</span></strong>
-                <ul class="mb-0 list-unstyled">${syner}</ul>
-                <strong>Trash <span class="badge bg-light text-dark ms-1">${trashVal}</span></strong>
-                <ul class="mb-0 list-unstyled">${trash}</ul>
-                <strong>Rare <span class="badge bg-light text-dark ms-1">${rareVal}</span></strong>
-                <ul class="mb-0 list-unstyled">${rare}</ul>
+            </div></div>
+            <div class="col">
+                <div class="summary-box summary-inner">
+                    <strong>Synergetics <span class="badge bg-light text-dark ms-1">${synerVal}</span></strong>
+                    <ul class="mb-0 list-unstyled">${syner}</ul>
+                </div>
+                <div class="summary-box summary-inner">
+                    <strong>Trash <span class="badge bg-light text-dark ms-1">${trashVal}</span></strong>
+                    <ul class="mb-0 list-unstyled">${trash}</ul>
+                </div>
+                <div class="summary-box summary-inner">
+                    <strong>Rare <span class="badge bg-light text-dark ms-1">${rareVal}</span></strong>
+                    <ul class="mb-0 list-unstyled">${rare}</ul>
+                </div>
             </div>
         </div>`;
 }


### PR DESCRIPTION
## Summary
- tune layout styling for summary widgets
- replace icons with text prefixes and remove Bootstrap icon dependency
- display item counts as badges and adjust list formatting
- separate synergetic/trash/rare sections in individual frames

## Testing
- `dotnet build BrokenStatsBackend.sln -c Release` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685170b153d08329b86e75f8d8024742