### PR TITLE
Fix PayloadLogger to receive full message

### DIFF
--- a/src/Network/PacketHandler.cs
+++ b/src/Network/PacketHandler.cs
@@ -65,11 +65,14 @@ namespace BrokenStatsBackend.src.Network
                     break;
                 }
 
+                byte[] fullMessageBytes = buffer.GetRange(0, endIndex).ToArray();
                 byte[] messageBytes = buffer.GetRange(startContent, endIndex - startContent).ToArray();
                 buffer.RemoveRange(0, endIndex + 1);
 
+                string fullMessage = Encoding.UTF8.GetString(fullMessageBytes);
+                PayloadLogger.SavePayload(fullMessage);
+
                 string message = Encoding.UTF8.GetString(messageBytes);
-                PayloadLogger.SavePayload(message);
                 matched.Consumer(timestamp, traceId, message);
                 found = true;
             } while (found);


### PR DESCRIPTION
## Summary
- ensure PacketHandler logs full packet including the start marker

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855d7c3d3fc832996d5b3ea4be22d26