### PR TITLE
Handle instance packets

### DIFF
--- a/src/Database/AppDbContext.cs
+++ b/src/Database/AppDbContext.cs
@@ -12,6 +12,7 @@ namespace BrokenStatsBackend.src.Database
         public DbSet<PriceEntity> Prices => Set<PriceEntity>();
         public DbSet<DropItemEntity> DropItems => Set<DropItemEntity>();
         public DbSet<DropTypeEntity> DropTypes => Set<DropTypeEntity>();
+        public DbSet<InstanceEntity> Instances => Set<InstanceEntity>();
 
 
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
@@ -26,6 +27,8 @@ namespace BrokenStatsBackend.src.Database
             modelBuilder.Entity<DropItemEntity>().HasIndex(x => new { x.Name, x.Quality }).IsUnique();
             modelBuilder.Entity<FightEntity>().HasIndex(f => f.PublicId).IsUnique();
             modelBuilder.Entity<FightEntity>().Property(f => f.Time).HasColumnType("DATETIME");
+            modelBuilder.Entity<InstanceEntity>().HasIndex(i => i.InstanceId).IsUnique();
+            modelBuilder.Entity<InstanceEntity>().Property(i => i.StartTime).HasColumnType("DATETIME");
 
         }
     }

--- a/src/Models/InstanceEntity.cs
+++ b/src/Models/InstanceEntity.cs
@@ -1,0 +1,11 @@
+using System;
+namespace BrokenStatsBackend.src.Models
+{
+    public class InstanceEntity
+    {
+        public int Id { get; set; }
+        public long InstanceId { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public DateTime StartTime { get; set; }
+    }
+}

--- a/src/Parser/InstanceParser.cs
+++ b/src/Parser/InstanceParser.cs
@@ -1,0 +1,25 @@
+using BrokenStatsBackend.src.Models;
+
+namespace BrokenStatsBackend.src.Parser;
+
+public static class InstanceParser
+{
+    public static InstanceEntity ToInstanceEntity(DateTime timestamp, string raw)
+    {
+        var parts = raw.Split("[$]");
+        if (parts.Length < 2)
+            throw new ArgumentException("Invalid instance packet");
+
+        if (!long.TryParse(parts[0], out long id))
+            throw new ArgumentException("Invalid instance id");
+
+        string name = parts[1].Trim('[', ']');
+
+        return new InstanceEntity
+        {
+            InstanceId = id,
+            Name = name,
+            StartTime = timestamp
+        };
+    }
+}

--- a/src/Repositories/InstanceRepository.cs
+++ b/src/Repositories/InstanceRepository.cs
@@ -1,0 +1,15 @@
+using BrokenStatsBackend.src.Database;
+using BrokenStatsBackend.src.Models;
+
+namespace BrokenStatsBackend.src.Repositories;
+
+public class InstanceRepository(AppDbContext context)
+{
+    private readonly AppDbContext _context = context;
+
+    public async Task AddInstanceAsync(InstanceEntity instance)
+    {
+        _context.Instances.Add(instance);
+        await _context.SaveChangesAsync();
+    }
+}


### PR DESCRIPTION
## Summary
- add new InstanceEntity to store info about started instance
- update DbContext to manage InstanceEntity
- implement parser for instance packets
- add repository and program logic to save instances

## Testing
- `dotnet build --no-restore` *(fails: command not found)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855e1fe38f4832986e876e307da4535