### PR TITLE
Handle repeated instance frames

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -76,8 +76,16 @@ Task task = Task.Run(() =>
     {
         try
         {
-            _ = completionTracker.StartNewInstanceAsync(timestamp);
             var instance = InstanceParser.ToInstanceEntity(timestamp, content);
+            var last = instanceRepository.GetLastInstanceAsync().GetAwaiter().GetResult();
+
+            if (last != null && last.EndTime == null && last.Name == instance.Name)
+            {
+                // continuation of the same instance - do nothing
+                return;
+            }
+
+            _ = completionTracker.StartNewInstanceAsync(timestamp);
             _ = instanceRepository.AddInstanceAsync(instance);
         }
         catch (Exception ex)

--- a/src/Repositories/InstanceRepository.cs
+++ b/src/Repositories/InstanceRepository.cs
@@ -27,4 +27,11 @@ public class InstanceRepository(AppDbContext context)
             await _context.SaveChangesAsync();
         }
     }
+
+    public async Task<InstanceEntity?> GetLastInstanceAsync()
+    {
+        return await _context.Instances
+            .OrderByDescending(i => i.StartTime)
+            .FirstOrDefaultAsync();
+    }
 }


### PR DESCRIPTION
## Summary
- skip starting a new instance when consecutive instance frames use the same name
- expose a method to fetch the last known instance

## Testing
- `dotnet build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68566f023bc4832995161fa8920a36d0