### PR TITLE
Add instance difficulty property

### DIFF
--- a/src/Models/InstanceEntity.cs
+++ b/src/Models/InstanceEntity.cs
@@ -6,6 +6,9 @@ namespace BrokenStatsBackend.src.Models
         public int Id { get; set; }
         public long InstanceId { get; set; }
         public string Name { get; set; } = string.Empty;
+        // Difficulty level of the instance:
+        // 1 - Normal, 2 - Easy, 3 - Hard
+        public int Difficulty { get; set; }
         public DateTime StartTime { get; set; }
         public DateTime? EndTime { get; set; }
     }

--- a/src/Parser/InstanceParser.cs
+++ b/src/Parser/InstanceParser.cs
@@ -14,11 +14,15 @@ public static class InstanceParser
             throw new ArgumentException("Invalid instance id");
 
         string name = parts[1].Trim('[', ']');
+        int difficulty = 1;
+        if (parts.Length >= 4 && int.TryParse(parts[3], out int d))
+            difficulty = d;
 
         return new InstanceEntity
         {
             InstanceId = id,
             Name = name,
+            Difficulty = difficulty,
             StartTime = timestamp
         };
     }


### PR DESCRIPTION
## Summary
- store instance difficulty in the database
- parse difficulty value from the incoming packet

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68567a6ce8708329b2ee7ea30da9a9e2