### PR TITLE
Add instances view and API

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -5,6 +5,7 @@ using BrokenStatsBackend.src.Parser;
 using Microsoft.EntityFrameworkCore;
 using BrokenStatsBackend.src.Network;
 using Microsoft.Extensions.FileProviders;
+using Microsoft.AspNetCore.Http;
 using System.Linq;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -32,6 +33,8 @@ app.UseCors();
 var frontendPath = Path.Combine(builder.Environment.ContentRootPath, "frontend");
 app.UseDefaultFiles(new DefaultFilesOptions { FileProvider = new PhysicalFileProvider(frontendPath) });
 app.UseStaticFiles(new StaticFileOptions { FileProvider = new PhysicalFileProvider(frontendPath) });
+app.MapGet("/fights", () => Results.PhysicalFile(Path.Combine(frontendPath, "index.html"), "text/html"));
+app.MapGet("/instances", () => Results.PhysicalFile(Path.Combine(frontendPath, "instances.html"), "text/html"));
 app.MapControllers();
 
 // 🔥 Sniffer w tle

--- a/frontend/instances.html
+++ b/frontend/instances.html
@@ -1,0 +1,118 @@
+<!DOCTYPE html>
+<html lang="pl">
+<head>
+    <meta charset="UTF-8">
+    <title>Instancje</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="style.css">
+</head>
+<body class="bg-dark text-light">
+    <h1 class="mb-3">Instancje</h1>
+    <div class="instances-layout">
+        <ul id="dayList" class="day-list"></ul>
+        <ul id="instanceList" class="instance-list"></ul>
+        <table id="fightsTable" class="custom-dark-table">
+            <thead>
+                <tr>
+                    <th scope="col">Czas</th>
+                    <th scope="col">Exp</th>
+                    <th scope="col">Gold</th>
+                    <th scope="col">Psycho</th>
+                    <th scope="col">Przeciwnicy</th>
+                    <th scope="col">Łupy</th>
+                </tr>
+            </thead>
+            <tbody></tbody>
+        </table>
+    </div>
+<script>
+let selectedDay = localStorage.getItem('selectedDay');
+let selectedInstance = localStorage.getItem('selectedInstance');
+
+function pad(n){return n.toString().padStart(2,'0');}
+function formatDate(d){return `${d.getFullYear()}-${pad(d.getMonth()+1)}-${pad(d.getDate())}`;}
+function formatMMSS(sec){const m=Math.floor(sec/60);const s=sec%60;return `${pad(m)}:${pad(s)}`;}
+
+async function loadDays(){
+    const days = await (await fetch('/api/instances/days')).json();
+    if(!selectedDay){ selectedDay = days[0].date; }
+    renderDayList(days);
+}
+
+function renderDayList(days){
+    const ul=document.getElementById('dayList');
+    ul.innerHTML='';
+    days.forEach(d=>{
+        const li=document.createElement('li');
+        li.textContent=`${d.date} (${d.count})`;
+        li.dataset.date=d.date;
+        if(d.date===selectedDay) li.classList.add('selected');
+        li.addEventListener('click',()=>{ selectedDay=d.date; localStorage.setItem('selectedDay',selectedDay); loadInstances(); renderDayList(days); });
+        ul.appendChild(li);
+    });
+}
+
+async function loadInstances(){
+    const res = await fetch('/api/instances/byDay?date='+selectedDay);
+    const list = await res.json();
+    renderInstanceList(list);
+}
+
+function renderInstanceList(list){
+    const ul=document.getElementById('instanceList');
+    ul.innerHTML='';
+    const none=document.createElement('li');
+    none.textContent='Bez instancji';
+    none.dataset.id='none';
+    if(!selectedInstance) selectedInstance='none';
+    if(selectedInstance==='none') none.classList.add('selected');
+    none.addEventListener('click',()=>{selectedInstance='none'; localStorage.setItem('selectedInstance',selectedInstance); loadFights(); renderInstanceList(list);});
+    ul.appendChild(none);
+    let defaultSet=false;
+    list.forEach(inst=>{
+        const diffChar = inst.difficulty===2?'Ł':inst.difficulty===1?'N':'T';
+        let time='trwa';
+        if(inst.endTime) {
+            const sec=Math.floor((new Date(inst.endTime)-new Date(inst.startTime))/1000);
+            time=formatMMSS(sec);
+        }
+        const li=document.createElement('li');
+        li.textContent=`${inst.name} [${diffChar}] (${time})`;
+        li.dataset.id=inst.id;
+        if(!selectedInstance && !defaultSet && !inst.endTime){selectedInstance=inst.id.toString();defaultSet=true;}
+        if(inst.id.toString()===selectedInstance) li.classList.add('selected');
+        li.addEventListener('click',()=>{selectedInstance=inst.id.toString(); localStorage.setItem('selectedInstance',selectedInstance); loadFights(); renderInstanceList(list);});
+        ul.appendChild(li);
+    });
+    localStorage.setItem('selectedInstance',selectedInstance);
+    loadFights();
+}
+
+async function loadFights(){
+    const tbody=document.querySelector('#fightsTable tbody');
+    tbody.innerHTML='';
+    if(selectedInstance==='none'){
+        const fights=await (await fetch('/api/instances/without/fights')).json();
+        fights.forEach(f=>{
+            const tr=document.createElement('tr');
+            const t=new Date(f.time);
+            const time=`${pad(t.getDate())}.${pad(t.getMonth()+1)} ${pad(t.getHours())}:${pad(t.getMinutes())}:${pad(t.getSeconds())}`;
+            tr.innerHTML=`<td>${time}</td><td>${f.exp}</td><td>${f.gold}</td><td>${f.psycho}</td><td>${f.opponents}</td><td>${f.drops}</td>`;
+            tbody.appendChild(tr);
+        });
+    }else{
+        const fights=await (await fetch('/api/instances/'+selectedInstance+'/fights')).json();
+        fights.forEach(f=>{
+            const tr=document.createElement('tr');
+            tr.innerHTML=`<td>${formatMMSS(f.offsetSeconds)}</td><td>${f.exp}</td><td>${f.gold}</td><td>${f.psycho}</td><td>${f.opponents}</td><td>${f.drops}</td>`;
+            tbody.appendChild(tr);
+        });
+    }
+}
+
+function refresh(){loadDays().then(loadInstances);}
+refresh();
+setInterval(refresh,10000);
+</script>
+</body>
+</html>

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -195,3 +195,31 @@ form {
   font-style: italic;
   color: #aaa;
 }
+
+.instances-layout {
+  display: grid;
+  grid-template-columns: 200px 200px 1fr;
+  gap: 20px;
+  max-width: 1400px;
+  margin: 0 auto;
+}
+.day-list, .instance-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  background-color: #1e1e1e;
+  border-radius: 12px;
+  max-height: 600px;
+  overflow-y: auto;
+}
+.day-list li, .instance-list li {
+  padding: 8px 12px;
+  border-bottom: 1px solid #333;
+  cursor: pointer;
+}
+.day-list li:hover, .instance-list li:hover {
+  background-color: #2e2e2e;
+}
+.day-list li.selected, .instance-list li.selected {
+  background-color: #0066cc;
+}

--- a/src/Controllers/InstancesController.cs
+++ b/src/Controllers/InstancesController.cs
@@ -1,0 +1,150 @@
+using BrokenStatsBackend.src.Database;
+using BrokenStatsBackend.src.Models;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace BrokenStatsBackend.src.Controllers;
+
+[ApiController]
+[Route("api/instances")]
+public class InstancesController(AppDbContext db) : ControllerBase
+{
+    private readonly AppDbContext _db = db;
+
+    [HttpGet("days")]
+    public async Task<IActionResult> GetDays()
+    {
+        DateTime today = DateTime.Today;
+        DateTime monthAgo = today.AddDays(-30);
+        var counts = await _db.Instances
+            .Where(i => i.StartTime.Date >= monthAgo)
+            .GroupBy(i => i.StartTime.Date)
+            .Select(g => new { Date = g.Key, Count = g.Count() })
+            .ToDictionaryAsync(g => g.Date, g => g.Count);
+        var result = Enumerable.Range(0, 31)
+            .Select(offset => today.AddDays(-offset))
+            .Select(d => new
+            {
+                date = d.ToString("yyyy-MM-dd"),
+                count = counts.TryGetValue(d, out var c) ? c : 0
+            });
+        return Ok(result);
+    }
+
+    [HttpGet("byDay")]
+    public async Task<IActionResult> GetByDay(DateTime date)
+    {
+        DateTime day = date.Date;
+        DateTime next = day.AddDays(1);
+        var list = await _db.Instances
+            .Where(i => i.StartTime >= day && i.StartTime < next)
+            .OrderBy(i => i.StartTime)
+            .Select(i => new
+            {
+                id = i.Id,
+                name = i.Name,
+                difficulty = i.Difficulty,
+                startTime = i.StartTime,
+                endTime = i.EndTime
+            }).ToListAsync();
+        return Ok(list);
+    }
+
+    [HttpGet("{id}/fights")]
+    public async Task<IActionResult> GetFights(int id)
+    {
+        var instance = await _db.Instances.FindAsync(id);
+        if (instance == null) return NotFound();
+        DateTime start = instance.StartTime;
+        DateTime end = instance.EndTime ?? DateTime.MaxValue;
+        var fights = await _db.Fights
+            .Include(f => f.Opponents).ThenInclude(o => o.OpponentType)
+            .Include(f => f.Drops).ThenInclude(d => d.DropItem).ThenInclude(di => di.DropType)
+            .Where(f => f.Time >= start && f.Time <= end)
+            .OrderBy(f => f.Time)
+            .ToListAsync();
+        var result = fights.Select(f => new InstanceFightDto
+        {
+            Id = f.PublicId,
+            OffsetSeconds = (int)(f.Time - start).TotalSeconds,
+            Exp = f.Exp,
+            Gold = f.Gold,
+            Psycho = f.Psycho,
+            Opponents = string.Join(", ",
+                f.Opponents
+                    .GroupBy(o => o.OpponentType.Name)
+                    .Select(g =>
+                    {
+                        int qty = g.Sum(o => o.Quantity);
+                        return qty > 1 ? $"{g.Key} ({qty})" : g.Key;
+                    })
+            ),
+            Drops = string.Join(", ",
+                f.Drops
+                    .Where(d => d.DropItem != null && d.DropItem.DropType != null)
+                    .OrderBy(d => DropTypeOrder(d.DropItem.DropType.Type))
+                    .ThenBy(d => d.DropItem.Name)
+                    .Select(d =>
+                    {
+                        var quality = string.IsNullOrWhiteSpace(d.DropItem.Quality) ? "" : $"[{d.DropItem.Quality}]";
+                        var amount = d.Quantity > 1 ? $" ({d.Quantity})" : "";
+                        return $"{d.DropItem.Name}{quality}{amount}";
+                    })
+            )
+        }).ToList();
+        return Ok(result);
+    }
+
+    [HttpGet("without/fights")]
+    public async Task<IActionResult> GetFightsWithoutInstance()
+    {
+        var fights = await _db.Fights
+            .Include(f => f.Opponents).ThenInclude(o => o.OpponentType)
+            .Include(f => f.Drops).ThenInclude(d => d.DropItem).ThenInclude(di => di.DropType)
+            .Where(f => !_db.Instances.Any(i => f.Time >= i.StartTime && f.Time <= (i.EndTime ?? DateTime.MaxValue)))
+            .OrderByDescending(f => f.Time)
+            .ToListAsync();
+        var result = fights.Select(f => new FightFlatDto
+        {
+            Id = f.PublicId,
+            Time = f.Time,
+            Exp = f.Exp,
+            Gold = f.Gold,
+            Psycho = f.Psycho,
+            Opponents = string.Join(", ",
+                f.Opponents
+                    .GroupBy(o => new { o.OpponentType.Name, o.OpponentType.Level })
+                    .Select(g =>
+                    {
+                        int qty = g.Sum(o => o.Quantity);
+                        var amount = qty > 1 ? $" ({qty})" : "";
+                        return $"{g.Key.Name}({g.Key.Level}){amount}";
+                    })
+            ),
+            Drops = string.Join(", ",
+                f.Drops
+                    .Where(d => d.DropItem != null && d.DropItem.DropType != null)
+                    .OrderBy(d => DropTypeOrder(d.DropItem.DropType.Type))
+                    .ThenBy(d => d.DropItem.Name)
+                    .Select(d =>
+                    {
+                        var quality = string.IsNullOrWhiteSpace(d.DropItem.Quality) ? "" : $"[{d.DropItem.Quality}]";
+                        var amount = d.Quantity > 1 ? $" ({d.Quantity})" : "";
+                        return $"{d.DropItem.Name}{quality}{amount}";
+                    })
+            )
+        }).ToList();
+        return Ok(result);
+    }
+
+    private static int DropTypeOrder(string type) => type.ToLower() switch
+    {
+        "rare" => 0,
+        "synergetic" => 1,
+        "drif" => 2,
+        "item" => 3,
+        "trash" => 4,
+        _ => 5
+    };
+}
+

--- a/src/Models/InstanceFightDto.cs
+++ b/src/Models/InstanceFightDto.cs
@@ -1,0 +1,12 @@
+namespace BrokenStatsBackend.src.Models;
+
+public class InstanceFightDto
+{
+    public Guid Id { get; set; }
+    public int OffsetSeconds { get; set; }
+    public int Exp { get; set; }
+    public int Gold { get; set; }
+    public int Psycho { get; set; }
+    public string Opponents { get; set; } = string.Empty;
+    public string Drops { get; set; } = string.Empty;
+}


### PR DESCRIPTION
## Summary
- add InstancesController and InstanceFightDto to expose instance data
- map `/fights` and `/instances` paths to HTML files
- add new `instances.html` page and related styles

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68568333c3048329bbf63c10b9042d91