### PR TITLE
Fix file serving for frontend

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -33,8 +33,8 @@ app.UseCors();
 var frontendPath = Path.Combine(builder.Environment.ContentRootPath, "frontend");
 app.UseDefaultFiles(new DefaultFilesOptions { FileProvider = new PhysicalFileProvider(frontendPath) });
 app.UseStaticFiles(new StaticFileOptions { FileProvider = new PhysicalFileProvider(frontendPath) });
-app.MapGet("/fights", () => Results.PhysicalFile(Path.Combine(frontendPath, "index.html"), "text/html"));
-app.MapGet("/instances", () => Results.PhysicalFile(Path.Combine(frontendPath, "instances.html"), "text/html"));
+app.MapGet("/fights", () => Results.File(Path.Combine(frontendPath, "index.html"), "text/html"));
+app.MapGet("/instances", () => Results.File(Path.Combine(frontendPath, "instances.html"), "text/html"));
 app.MapControllers();
 
 // 🔥 Sniffer w tle


### PR DESCRIPTION
## Summary
- fix Results.PhysicalFile compile error by using `Results.File`

## Testing
- `N/A`

------
https://chatgpt.com/codex/tasks/task_e_68568a5e60d883299707364adc4a7e6b