### PR TITLE
Update instances page layout

### DIFF
--- a/frontend/instances.html
+++ b/frontend/instances.html
@@ -4,12 +4,12 @@
     <meta charset="UTF-8">
     <title>Instancje</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
-    <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="/style.css">
 </head>
 <body class="bg-dark text-light">
     <h1 class="mb-3">Instancje</h1>
-    <section id="summary" class="mb-3"></section>
     <div class="instances-layout">
+        <section id="summary" class="mb-3 summary-cell"></section>
         <ul id="dayList" class="day-list"></ul>
         <ul id="instanceList" class="instance-list"></ul>
         <table id="fightsTable" class="custom-dark-table">
@@ -38,6 +38,14 @@ const instanceFights = {};
 const instanceDay = {};
 let lastClickedIndex = null;
 
+function getNoneFightsForDay(date){
+    const all = instanceFights['none'] || [];
+    return all.filter(f=>{
+        const d = new Date(f.time).toISOString().split('T')[0];
+        return d === date;
+    });
+}
+
 function pad(n){return n.toString().padStart(2,'0');}
 function formatMMSS(sec){const m=Math.floor(sec/60);const s=sec%60;return `${pad(m)}:${pad(s)}`;}
 function formatDateTime(value){const d=new Date(value);const p=n=>n.toString().padStart(2,'0');return `${p(d.getDate())}.${p(d.getMonth()+1)}.${d.getFullYear().toString().slice(-2)}, ${p(d.getHours())}:${p(d.getMinutes())}:${p(d.getSeconds())}`;}
@@ -52,6 +60,7 @@ async function loadDays(){
         dayInstances[d.date]=list;
         list.forEach(i=>{instanceDay[i.id]=d.date;});
     }));
+    await loadInstanceFights('none');
     await initializeSelections();
     renderDayList(days);
     loadInstances();
@@ -85,10 +94,16 @@ function renderDayList(days){
 }
 
 async function toggleDay(date, state){
-    const list = dayInstances[date];
+    const list = dayInstances[date] || [];
     for(const inst of list){
         await toggleInstance(inst.id,state,false);
     }
+    const noneFights = getNoneFightsForDay(date);
+    noneFights.forEach(f=>{
+        const id=f.id.toString();
+        if(state) selectedIds.add(id); else selectedIds.delete(id);
+    });
+    updateInstanceState('none');
     updateDayState(date);
     updateSummary();
 }
@@ -169,9 +184,16 @@ function updateInstanceState(id){
     if(!fights){
         cb.checked=selectedInstances.has(id);
         cb.indeterminate=false;
+        cb.disabled=false;
         return;
     }
     const total=fights.length;
+    cb.disabled=total===0;
+    if(total===0){
+        cb.checked=false;
+        cb.indeterminate=false;
+        return;
+    }
     const sel=fights.filter(f=>selectedIds.has(f.id.toString())).length;
     cb.indeterminate=sel>0 && sel<total;
     cb.checked=sel===total;
@@ -180,15 +202,25 @@ function updateInstanceState(id){
 function updateDayState(date){
     const cb=document.querySelector(`input[data-date="${date}"]`);
     if(!cb) return;
-    const list=dayInstances[date];
-    if(!list){cb.checked=false;cb.indeterminate=false;return;}
-    const states=list.map(inst=>{
+    const list=dayInstances[date] || [];
+    const noneFights=getNoneFightsForDay(date);
+    if(list.length===0 && noneFights.length===0){
+        cb.checked=false;cb.indeterminate=false;cb.disabled=true;return;
+    }
+    cb.disabled=false;
+    const states=[];
+    if(noneFights.length>0){
+        const total=noneFights.length;
+        const sel=noneFights.filter(f=>selectedIds.has(f.id.toString())).length;
+        if(sel===0) states.push(0); else if(sel===total) states.push(1); else states.push(0.5);
+    }
+    states.push(...list.map(inst=>{
         const fights=instanceFights[inst.id];
         if(!fights) return selectedInstances.has(inst.id)?1:0;
         const total=fights.length;
         const sel=fights.filter(f=>selectedIds.has(f.id.toString())).length;
         if(sel===0) return 0; if(sel===total) return 1; return 0.5;
-    });
+    }));
     if(states.every(s=>s===1)) {cb.checked=true;cb.indeterminate=false;}
     else if(states.every(s=>s===0)) {cb.checked=false;cb.indeterminate=false;}
     else {cb.checked=false;cb.indeterminate=true;}
@@ -198,7 +230,14 @@ async function loadFights(){
     const tbody=document.querySelector('#fightsTable tbody');
     tbody.innerHTML='';
     const fights = await loadInstanceFights(viewedInstance);
-    fights.forEach((f,i)=>{
+    let list=fights;
+    if(viewedInstance==='none'){
+        list=fights.filter(f=>{
+            const d=new Date(f.time).toISOString().split('T')[0];
+            return d===selectedDay;
+        });
+    }
+    list.forEach((f,i)=>{
         const tr=document.createElement('tr');
         const checked=selectedIds.has(f.id.toString())?'checked':'';
         const displayTime = viewedInstance==='none' ? (()=>{const t=new Date(f.time);return `${pad(t.getDate())}.${pad(t.getMonth()+1)} ${pad(t.getHours())}:${pad(t.getMinutes())}:${pad(t.getSeconds())}`;})() : formatMMSS(f.offsetSeconds);
@@ -215,6 +254,8 @@ async function loadFights(){
             else {if(cb.checked) selectedIds.add(id); else selectedIds.delete(id);} lastClickedIndex=index; updateInstanceState(viewedInstance); if(instanceDay[viewedInstance]) updateDayState(instanceDay[viewedInstance]); updateSelectAllState(); updateSummary();});
     });
     updateSelectAllState();
+    updateInstanceState(viewedInstance);
+    if(instanceDay[viewedInstance]) updateDayState(instanceDay[viewedInstance]);
 }
 
 function updateSelectAllState(){

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -199,9 +199,14 @@ form {
 .instances-layout {
   display: grid;
   grid-template-columns: 200px 200px 1fr;
+  grid-template-rows: auto 1fr;
   gap: 20px;
   max-width: 1400px;
   margin: 0 auto;
+}
+
+.summary-cell {
+  grid-column: 1 / -1;
 }
 .day-list, .instance-list {
   list-style: none;


### PR DESCRIPTION
## Summary
- fix style path and restructure instances layout
- group 'no instance' fights by day
- disable checkboxes when no fights
- keep summary as grid header

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68568db5b7cc8329912ac4309694bc38