### PR TITLE
Add deselect option and drop value

### DIFF
--- a/frontend/instances.html
+++ b/frontend/instances.html
@@ -10,6 +10,7 @@
     <h1 class="mb-3">Instancje</h1>
     <div class="instances-layout">
         <section id="summary" class="mb-3 summary-cell"></section>
+        <button id="clearSelection" class="btn btn-secondary summary-cell mb-3">Odznacz wszystko</button>
         <ul id="dayList" class="day-list"></ul>
         <ul id="instanceList" class="instance-list"></ul>
         <table id="fightsTable" class="custom-dark-table">
@@ -21,7 +22,7 @@
                     <th scope="col">Gold</th>
                     <th scope="col">Psycho</th>
                     <th scope="col">Przeciwnicy</th>
-                    <th scope="col">Łupy</th>
+                    <th scope="col">Wartość</th>
                 </tr>
             </thead>
             <tbody></tbody>
@@ -38,6 +39,7 @@ const dayInstances = {};
 const instanceFights = {};
 const instanceDay = {};
 let lastClickedIndex = null;
+let loadToken = 0;
 
 function getNoneFightsForDay(date){
     const all = instanceFights['none'] || [];
@@ -248,9 +250,12 @@ function updateDayState(date){
 }
 
 async function loadFights(){
+    const token = ++loadToken;
     const tbody=document.querySelector('#fightsTable tbody');
     tbody.innerHTML='';
     const fights = await loadInstanceFights(viewedInstance);
+    if(token!==loadToken) return;
+    lastClickedIndex=null;
     let list=fights;
     if(viewedInstance==='none'){
         list=fights.filter(f=>{
@@ -262,7 +267,7 @@ async function loadFights(){
         const tr=document.createElement('tr');
         const checked=selectedIds.has(f.id.toString())?'checked':'';
         const displayTime = viewedInstance==='none' ? (()=>{const t=new Date(f.time);return `${pad(t.getDate())}.${pad(t.getMonth()+1)} ${pad(t.getHours())}:${pad(t.getMinutes())}:${pad(t.getSeconds())}`;})() : formatMMSS(f.offsetSeconds);
-        tr.innerHTML=`<td><input type="checkbox" data-fight="${f.id}" data-index="${i}" ${checked}></td><td>${displayTime}</td><td>${f.exp}</td><td>${f.gold}</td><td>${f.psycho}</td><td>${f.opponents}</td><td>${f.drops}</td>`;
+        tr.innerHTML=`<td><input type="checkbox" data-fight="${f.id}" data-index="${i}" ${checked}></td><td>${displayTime}</td><td>${f.exp}</td><td>${f.gold}</td><td>${f.psycho}</td><td>${f.opponents}</td><td>${formatNumber(f.dropValue)}</td>`;
         tbody.appendChild(tr);
     });
     const checkboxes=Array.from(tbody.querySelectorAll('input[type="checkbox"]'));
@@ -289,6 +294,26 @@ function updateSelectAllState(){
 document.getElementById('selectAll').addEventListener('change',e=>{
     document.querySelectorAll('#fightsTable tbody input[type="checkbox"]').forEach(cb=>{cb.checked=e.target.checked;const id=cb.getAttribute('data-fight');if(cb.checked) selectedIds.add(id); else selectedIds.delete(id);});
     updateInstanceState(viewedInstance); if(instanceDay[viewedInstance]) updateDayState(instanceDay[viewedInstance]); updateSummary();});
+
+document.getElementById('clearSelection').addEventListener('click', clearSelection);
+
+function clearSelection(){
+    selectedIds.clear();
+    selectedInstances.clear();
+    selectedNoneDays.clear();
+    localStorage.setItem('selectedInstances','[]');
+    localStorage.setItem('selectedNoneDays','[]');
+    lastClickedIndex=null;
+    document.querySelectorAll('#fightsTable tbody input[type="checkbox"]').forEach(cb=>cb.checked=false);
+    document.querySelectorAll('#instanceList input[type="checkbox"]').forEach(cb=>{cb.checked=false;cb.indeterminate=false;});
+    document.querySelectorAll('#dayList input[type="checkbox"]').forEach(cb=>{cb.checked=false;cb.indeterminate=false;cb.disabled=false;});
+    document.getElementById('selectAll').checked=false;
+    Object.values(dayInstances).flat().forEach(inst=>updateInstanceState(inst.id));
+    updateInstanceState('none');
+    Object.keys(dayInstances).forEach(d=>updateDayState(d));
+    updateSummary();
+    updateSelectAllState();
+}
 
 async function updateSummary(){
     if(selectedIds.size===0){

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -198,7 +198,7 @@ form {
 
 .instances-layout {
   display: grid;
-  grid-template-columns: 200px 200px 1fr;
+  grid-template-columns: 200px 300px 1fr;
   grid-template-rows: auto 1fr;
   gap: 20px;
   max-width: 1400px;

--- a/src/Controllers/FightController.cs
+++ b/src/Controllers/FightController.cs
@@ -41,6 +41,7 @@ public class FightsController(AppDbContext db) : ControllerBase
             Exp = fight.Exp,
             Gold = fight.Gold,
             Psycho = fight.Psycho,
+            DropValue = fight.Drops.Sum(GetDropValue),
             Opponents = string.Join(", ",
                 fight.Opponents
                     .GroupBy(o => new { o.OpponentType.Name, o.OpponentType.Level })
@@ -217,6 +218,8 @@ public class FightsController(AppDbContext db) : ControllerBase
         });
     }
 
+
+    public static int GetDropValueStatic(DropEntity drop) => GetDropValue(drop);
 
     private static int GetDropValue(DropEntity drop)
     {

--- a/src/Controllers/InstancesController.cs
+++ b/src/Controllers/InstancesController.cs
@@ -68,6 +68,7 @@ public class InstancesController(AppDbContext db) : ControllerBase
             Exp = f.Exp,
             Gold = f.Gold,
             Psycho = f.Psycho,
+            DropValue = f.Drops.Sum(FightsController.GetDropValueStatic),
             Opponents = string.Join(", ",
                 f.Opponents
                     .GroupBy(o => o.OpponentType.Name)
@@ -109,6 +110,7 @@ public class InstancesController(AppDbContext db) : ControllerBase
             Exp = f.Exp,
             Gold = f.Gold,
             Psycho = f.Psycho,
+            DropValue = f.Drops.Sum(FightsController.GetDropValueStatic),
             Opponents = string.Join(", ",
                 f.Opponents
                     .GroupBy(o => new { o.OpponentType.Name, o.OpponentType.Level })

--- a/src/Models/FightFlatDto.cs
+++ b/src/Models/FightFlatDto.cs
@@ -7,6 +7,7 @@ namespace BrokenStatsBackend.src.Models
         public int Exp { get; set; }
         public int Gold { get; set; }
         public int Psycho { get; set; }
+        public int DropValue { get; set; }
         public string Opponents { get; set; } = string.Empty;
         public string Drops { get; set; } = string.Empty;
     }

--- a/src/Models/InstanceFightDto.cs
+++ b/src/Models/InstanceFightDto.cs
@@ -7,6 +7,7 @@ public class InstanceFightDto
     public int Exp { get; set; }
     public int Gold { get; set; }
     public int Psycho { get; set; }
+    public int DropValue { get; set; }
     public string Opponents { get; set; } = string.Empty;
     public string Drops { get; set; } = string.Empty;
 }


### PR DESCRIPTION
## Summary
- add `DropValue` to DTOs and expose helper method
- show total drop value in fights table instead of item list
- add 'Odznacz wszystko' button to clear all selections
- enlarge second column of instances list
- avoid stale fight rows when switching instances

## Testing
- `dotnet --version` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68569b43c924832986acea70cc6730a1