### PR TITLE
Fix instance order and table height

### DIFF
--- a/frontend/instances.html
+++ b/frontend/instances.html
@@ -138,6 +138,8 @@ function renderInstanceList(list){
     none.addEventListener('click',e=>{if(e.target===noneCb) return;viewedInstance='none'; localStorage.setItem('selectedInstance',viewedInstance); loadFights(); renderInstanceList(list);});
     ul.appendChild(none);
     updateInstanceState('none');
+    // Sort instances by start time descending so the newest are first
+    list.sort((a,b)=> new Date(b.startTime) - new Date(a.startTime));
     list.forEach(inst=>{
         const diffChar = inst.difficulty===2?'Ł':inst.difficulty===1?'N':'T';
         let time='trwa';

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -199,7 +199,8 @@ form {
 .instances-layout {
   display: grid;
   grid-template-columns: 200px 300px 1fr;
-  grid-template-rows: auto 1fr;
+  /* Avoid stretching the fights table when it has little content */
+  grid-template-rows: auto auto;
   gap: 20px;
   max-width: 1400px;
   margin: 0 auto;


### PR DESCRIPTION
## Summary
- sort instances by start time descending so newest appear first
- prevent the table from stretching when it has little content

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68569e7868ec8329b604c533db2ace2e