### PR TITLE
Fix fights table height

### DIFF
--- a/frontend/style.css
+++ b/frontend/style.css
@@ -201,6 +201,7 @@ form {
   grid-template-columns: 200px 300px 1fr;
   /* Avoid stretching the fights table when it has little content */
   grid-template-rows: auto auto;
+  align-items: start;
   gap: 20px;
   max-width: 1400px;
   margin: 0 auto;


### PR DESCRIPTION
## Summary
- prevent fights table from stretching by aligning items at the start of the grid

## Testing
- `dotnet build BrokenStatsBackend.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856a12585548329b2b6be3abcefb206