### PR TITLE
Fix script placement for modal

### DIFF
--- a/frontend/instances.html
+++ b/frontend/instances.html
@@ -30,6 +30,34 @@
         </table>
     </div>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+<div class="modal fade" id="createInstanceModal" tabindex="-1">
+  <div class="modal-dialog">
+    <div class="modal-content bg-dark text-light">
+      <div class="modal-header">
+        <h5 class="modal-title">Utwórz instancję</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <div class="mb-3">
+          <label class="form-label">Nazwa</label>
+          <input type="text" id="instanceName" class="form-control">
+        </div>
+        <div class="mb-3">
+          <label class="form-label">Poziom trudności</label>
+          <select id="instanceDifficulty" class="form-select">
+            <option value="1">Normalny</option>
+            <option value="2">Łatwy</option>
+            <option value="3">Trudny</option>
+          </select>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Anuluj</button>
+        <button type="button" id="confirmCreateInstance" class="btn btn-primary">Utwórz</button>
+      </div>
+    </div>
+  </div>
+</div>
 <script>
 let selectedDay = localStorage.getItem('selectedDay');
 let viewedInstance = localStorage.getItem('selectedInstance');
@@ -379,33 +407,5 @@ function refresh(){loadDays();}
 refresh();
 setInterval(refresh,10000);
 </script>
-<div class="modal fade" id="createInstanceModal" tabindex="-1">
-  <div class="modal-dialog">
-    <div class="modal-content bg-dark text-light">
-      <div class="modal-header">
-        <h5 class="modal-title">Utwórz instancję</h5>
-        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-      </div>
-      <div class="modal-body">
-        <div class="mb-3">
-          <label class="form-label">Nazwa</label>
-          <input type="text" id="instanceName" class="form-control">
-        </div>
-        <div class="mb-3">
-          <label class="form-label">Poziom trudności</label>
-          <select id="instanceDifficulty" class="form-select">
-            <option value="1">Normalny</option>
-            <option value="2">Łatwy</option>
-            <option value="3">Trudny</option>
-          </select>
-        </div>
-      </div>
-      <div class="modal-footer">
-        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Anuluj</button>
-        <button type="button" id="confirmCreateInstance" class="btn btn-primary">Utwórz</button>
-      </div>
-    </div>
-  </div>
-</div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- place modal markup before inline script in `instances.html`
- keep `confirmCreateInstance` hook after modal is parsed

## Testing
- `dotnet build --no-restore` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6856a40ac2488329a7bee0ac4574d6f3