### PR TITLE
Add Development environment note

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# BrokenStats Backend
+
+This is a small backend service used to collect and serve fight data.
+
+## Running
+
+Start the API with:
+
+```bash
+dotnet run
+```
+
+It listens on `http://localhost:5005`.
+
+## Environment
+
+The application checks the `ASPNETCORE_ENVIRONMENT` variable to determine the environment. When set to `Development`, `UseDeveloperExceptionPage()` is invoked which shows detailed error pages and enables more verbose logging. In other environments the generic `/error` endpoint is used.
+


### PR DESCRIPTION
## Summary
- add a simple root README with instructions
- note that setting `ASPNETCORE_ENVIRONMENT=Development` shows detailed error pages

## Testing
- `dotnet build --no-restore` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856b3e262a4832997e20f75e08b0fda