### PR TITLE
Improve instance list layout

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -8,6 +8,7 @@
 </head>
 <body class="bg-dark text-light">
     <h1 class="mb-3">Zepsute Statystyki</h1>
+    <div id="stickyBar" class="sticky-bar">
     <form id="queryForm" class="mb-3">
         <div class="row g-2 align-items-end">
             <div class="col-auto">
@@ -36,7 +37,11 @@
             </div>
         </div>
     </form>
+    <div class="button-row mb-3">
+        <button id="toggleSummary" class="btn btn-secondary">Ukryj podsumowanie</button>
+    </div>
     <section id="summary" class="mb-3"></section>
+    </div>
     <div class="fights-wrapper">
         <table id="fightsTable" class="custom-dark-table">
             <thead>
@@ -111,6 +116,12 @@ document.getElementById('selectAll').addEventListener('change', e => {
         if(cb.checked) selectedIds.add(id); else selectedIds.delete(id);
     });
     updateSummary();
+});
+document.getElementById('toggleSummary').addEventListener('click', ()=>{
+    const s=document.getElementById('summary');
+    const btn=document.getElementById('toggleSummary');
+    if(s.style.display==='none'){s.style.display='';btn.textContent='Ukryj podsumowanie';}
+    else {s.style.display='none';btn.textContent='Pokaż podsumowanie';}
 });
 
 window.onload = setToday;

--- a/frontend/instances.html
+++ b/frontend/instances.html
@@ -9,9 +9,14 @@
 <body class="bg-dark text-light">
     <h1 class="mb-3">Instancje</h1>
     <div class="instances-layout">
-        <section id="summary" class="mb-3 summary-cell"></section>
-        <button id="clearSelection" class="btn btn-secondary summary-cell mb-3">Odznacz wszystko</button>
-        <button id="newInstanceBtn" class="btn btn-primary summary-cell mb-3">Utwórz instancję</button>
+        <div id="stickyBar" class="summary-cell sticky-bar">
+            <section id="summary" class="mb-3"></section>
+            <div class="button-row mb-3">
+                <button id="clearSelection" class="btn btn-secondary">Odznacz wszystko</button>
+                <button id="newInstanceBtn" class="btn btn-primary">Utwórz instancję</button>
+                <button id="toggleSummary" class="btn btn-secondary">Ukryj podsumowanie</button>
+            </div>
+        </div>
         <ul id="dayList" class="day-list"></ul>
         <ul id="instanceList" class="instance-list"></ul>
         <table id="fightsTable" class="custom-dark-table">
@@ -329,6 +334,17 @@ document.getElementById('selectAll').addEventListener('change',e=>{
 
 document.getElementById('clearSelection').addEventListener('click', clearSelection);
 document.getElementById('newInstanceBtn').addEventListener('click', openCreateInstanceModal);
+document.getElementById('toggleSummary').addEventListener('click', () => {
+    const s = document.getElementById('summary');
+    const btn = document.getElementById('toggleSummary');
+    if (s.style.display === 'none') {
+        s.style.display = '';
+        btn.textContent = 'Ukryj podsumowanie';
+    } else {
+        s.style.display = 'none';
+        btn.textContent = 'Pokaż podsumowanie';
+    }
+});
 
 function clearSelection(){
     selectedIds.clear();

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -207,6 +207,19 @@ form {
   margin: 0 auto;
 }
 
+.sticky-bar {
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  background-color: #121212;
+  padding-top: 20px;
+}
+
+.button-row {
+  display: flex;
+  gap: 10px;
+}
+
 .summary-cell {
   grid-column: 1 / -1;
 }
@@ -216,8 +229,6 @@ form {
   padding: 0;
   background-color: #1e1e1e;
   border-radius: 12px;
-  max-height: 600px;
-  overflow-y: auto;
 }
 .day-list li, .instance-list li {
   padding: 8px 12px;


### PR DESCRIPTION
## Summary
- make day and instance lists fully expand
- add sticky bar with collapse button for summary on both pages
- group clear/create buttons into a row
- allow toggling summary visibility

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856ced0704c8329999387fe062f53a6