### PR TITLE
Add row and drag selection for fights

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -113,7 +113,9 @@ document.getElementById('selectAll').addEventListener('change', e => {
     document.querySelectorAll('#fightsTable tbody input[type="checkbox"]').forEach(cb => {
         cb.checked = e.target.checked;
         const id = cb.getAttribute('data-id');
-        if(cb.checked) selectedIds.add(id); else selectedIds.delete(id);
+        const row = cb.closest('tr');
+        if(cb.checked){ selectedIds.add(id); row.classList.add('selected'); }
+        else { selectedIds.delete(id); row.classList.remove('selected'); }
     });
     updateSummary();
 });
@@ -155,32 +157,72 @@ function renderTable(fights){
             <td>${f.psycho}</td>
             <td>${f.opponents}</td>
             <td>${f.drops}</td>`;
+        if(checked) tr.classList.add('selected');
         tbody.appendChild(tr);
     });
     const checkboxes = Array.from(tbody.querySelectorAll('input[type="checkbox"]'));
+    const rows = Array.from(tbody.querySelectorAll('tr'));
+
+    function setChecked(idx, state){
+        const cb = checkboxes[idx];
+        if(!cb) return;
+        cb.checked = state;
+        const row = rows[idx];
+        const id = cb.getAttribute('data-id');
+        if(state) { selectedIds.add(id); row.classList.add('selected'); }
+        else { selectedIds.delete(id); row.classList.remove('selected'); }
+    }
+
     checkboxes.forEach((cb, index) => {
         cb.dataset.index = index;
         cb.addEventListener('click', e => {
+            if(dragging){ e.preventDefault(); return; }
             const id = cb.getAttribute('data-id');
             if(e.shiftKey && lastClickedIndex !== null){
                 const start = Math.min(lastClickedIndex, index);
                 const end = Math.max(lastClickedIndex, index);
                 const targetState = cb.checked;
                 for(let i=start; i<=end && i<checkboxes.length; i++){
-                    const other = checkboxes[i];
-                    if(!other) continue;
-                    other.checked = targetState;
-                    const otherId = other.getAttribute('data-id');
-                    if(targetState) selectedIds.add(otherId); else selectedIds.delete(otherId);
+                    setChecked(i, targetState);
                 }
             } else {
-                if(cb.checked) selectedIds.add(id); else selectedIds.delete(id);
+                setChecked(index, cb.checked);
             }
             lastClickedIndex = index;
             updateSummary();
             updateSelectAllState();
         });
     });
+
+    let dragging = false;
+    let dragStart = null;
+    let dragState = null;
+
+    function applyDrag(end){
+        const start = Math.min(dragStart, end);
+        const stop = Math.max(dragStart, end);
+        for(let i=start; i<=stop && i<checkboxes.length; i++){
+            setChecked(i, dragState);
+        }
+        lastClickedIndex = end;
+    }
+
+    rows.forEach((row, idx)=>{
+        row.dataset.index = idx;
+        row.addEventListener('mousedown', e=>{
+            if(e.button!==0) return;
+            dragging = true;
+            dragStart = idx;
+            dragState = !checkboxes[idx].checked;
+            applyDrag(idx);
+            e.preventDefault();
+        });
+        row.addEventListener('mouseenter', ()=>{ if(dragging) applyDrag(idx); });
+    });
+    document.addEventListener('mouseup', ()=>{
+        if(dragging){ dragging = false; updateSummary(); updateSelectAllState(); }
+    });
+
     updateSummary();
     updateSelectAllState();
 }

--- a/frontend/instances.html
+++ b/frontend/instances.html
@@ -305,17 +305,69 @@ async function loadFights(){
         const checked=selectedIds.has(f.id.toString())?'checked':'';
         const displayTime = viewedInstance==='none' ? (()=>{const t=new Date(f.time);return `${pad(t.getDate())}.${pad(t.getMonth()+1)} ${pad(t.getHours())}:${pad(t.getMinutes())}:${pad(t.getSeconds())}`;})() : formatMMSS(f.offsetSeconds);
         tr.innerHTML=`<td><input type="checkbox" data-fight="${f.id}" data-index="${i}" ${checked}></td><td>${displayTime}</td><td>${f.exp}</td><td>${f.gold}</td><td>${f.psycho}</td><td>${f.opponents}</td><td>${formatNumber(f.dropValue)}</td>`;
+        if(checked) tr.classList.add('selected');
         tbody.appendChild(tr);
     });
     const checkboxes=Array.from(tbody.querySelectorAll('input[type="checkbox"]'));
+    const rows = Array.from(tbody.querySelectorAll('tr'));
+
+    function setChecked(idx,state){
+        const cb=checkboxes[idx];
+        if(!cb) return;
+        cb.checked=state;
+        const row=rows[idx];
+        const id=cb.getAttribute('data-fight');
+        if(state){selectedIds.add(id); row.classList.add('selected');}
+        else{selectedIds.delete(id); row.classList.remove('selected');}
+    }
+
     checkboxes.forEach((cb,index)=>{
         cb.dataset.index=index;
         cb.addEventListener('click',e=>{
-            const id=cb.getAttribute('data-fight');
+            if(dragging){e.preventDefault();return;}
             if(e.shiftKey && lastClickedIndex!==null){
-                const start=Math.min(lastClickedIndex,index);const end=Math.max(lastClickedIndex,index);const target=cb.checked;for(let i=start;i<=end;i++){const other=checkboxes[i];other.checked=target;const otherId=other.getAttribute('data-fight');if(target) selectedIds.add(otherId); else selectedIds.delete(otherId);} }
-            else {if(cb.checked) selectedIds.add(id); else selectedIds.delete(id);} lastClickedIndex=index; updateInstanceState(viewedInstance); if(instanceDay[viewedInstance]) updateDayState(instanceDay[viewedInstance]); updateSelectAllState(); updateSummary();});
+                const start=Math.min(lastClickedIndex,index);
+                const end=Math.max(lastClickedIndex,index);
+                const target=cb.checked;
+                for(let i=start;i<=end;i++) setChecked(i,target);
+            } else {
+                setChecked(index,cb.checked);
+            }
+            lastClickedIndex=index;
+            updateInstanceState(viewedInstance);
+            if(instanceDay[viewedInstance]) updateDayState(instanceDay[viewedInstance]);
+            updateSelectAllState();
+            updateSummary();
+        });
     });
+
+    let dragging=false;
+    let dragStart=null;
+    let dragState=null;
+
+    function applyDrag(end){
+        const start=Math.min(dragStart,end);
+        const stop=Math.max(dragStart,end);
+        for(let i=start;i<=stop;i++) setChecked(i,dragState);
+        lastClickedIndex=end;
+    }
+
+    rows.forEach((row,idx)=>{
+        row.dataset.index=idx;
+        row.addEventListener('mousedown',e=>{
+            if(e.button!==0) return;
+            dragging=true;
+            dragStart=idx;
+            dragState=!checkboxes[idx].checked;
+            applyDrag(idx);
+            e.preventDefault();
+        });
+        row.addEventListener('mouseenter',()=>{if(dragging) applyDrag(idx);});
+    });
+    document.addEventListener('mouseup',()=>{
+        if(dragging){dragging=false;updateInstanceState(viewedInstance);if(instanceDay[viewedInstance]) updateDayState(instanceDay[viewedInstance]);updateSelectAllState();updateSummary();}
+    });
+
     updateSelectAllState();
     updateInstanceState(viewedInstance);
     if(instanceDay[viewedInstance]) updateDayState(instanceDay[viewedInstance]);
@@ -329,7 +381,13 @@ function updateSelectAllState(){
 }
 
 document.getElementById('selectAll').addEventListener('change',e=>{
-    document.querySelectorAll('#fightsTable tbody input[type="checkbox"]').forEach(cb=>{cb.checked=e.target.checked;const id=cb.getAttribute('data-fight');if(cb.checked) selectedIds.add(id); else selectedIds.delete(id);});
+    document.querySelectorAll('#fightsTable tbody input[type="checkbox"]').forEach(cb=>{
+        cb.checked=e.target.checked;
+        const id=cb.getAttribute('data-fight');
+        const row=cb.closest('tr');
+        if(cb.checked){selectedIds.add(id); row.classList.add('selected');}
+        else{selectedIds.delete(id); row.classList.remove('selected');}
+    });
     updateInstanceState(viewedInstance); if(instanceDay[viewedInstance]) updateDayState(instanceDay[viewedInstance]); updateSummary();});
 
 document.getElementById('clearSelection').addEventListener('click', clearSelection);
@@ -353,7 +411,7 @@ function clearSelection(){
     localStorage.setItem('selectedInstances','[]');
     localStorage.setItem('selectedNoneDays','[]');
     lastClickedIndex=null;
-    document.querySelectorAll('#fightsTable tbody input[type="checkbox"]').forEach(cb=>cb.checked=false);
+    document.querySelectorAll('#fightsTable tbody input[type="checkbox"]').forEach(cb=>{cb.checked=false; cb.closest('tr').classList.remove('selected');});
     document.querySelectorAll('#instanceList input[type="checkbox"]').forEach(cb=>{cb.checked=false;cb.indeterminate=false;});
     document.querySelectorAll('#dayList input[type="checkbox"]').forEach(cb=>{cb.checked=false;cb.indeterminate=false;cb.disabled=false;});
     document.getElementById('selectAll').checked=false;

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -167,6 +167,10 @@ form {
   background-color: #2e2e2e;
 }
 
+.custom-dark-table tbody tr.selected {
+  background-color: #0066cc;
+}
+
 .custom-dark-table td {
   padding: 10px 12px;
   border-bottom: 1px solid #333;


### PR DESCRIPTION
## Summary
- allow selecting fight rows by clicking anywhere in the row
- support selecting multiple fights by dragging across rows
- highlight selected rows in the fights tables

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856d1cbc4cc8329910ee7c4c4676cf8