### PR TITLE
Add total gold with drops to summary

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -262,6 +262,7 @@ async function updateSummary(){
     const synerVal = formatNumber(dropValues['synergetic'] || 0);
     const trashVal = formatNumber(dropValues['trash'] || 0);
     const rareVal = formatNumber(dropValues['rare'] || 0);
+    const totalGoldWithDrops = formatNumber(summary.totalGoldWithDrops);
     const day = formatDateTime(summary.sessionStart).split(',')[0];
     const duration = formatDuration(new Date(summary.sessionEnd) - new Date(summary.sessionStart));
     s.innerHTML = `
@@ -273,6 +274,10 @@ async function updateSummary(){
             <div class="summary-card">
                 <div class="summary-title">Gold</div>
                 <div class="summary-value">${formatNumber(summary.totalGold)}</div>
+            </div>
+            <div class="summary-card">
+                <div class="summary-title">Gold łącznie</div>
+                <div class="summary-value">${totalGoldWithDrops}</div>
             </div>
             <div class="summary-card">
                 <div class="summary-title">Psycho</div>

--- a/frontend/instances.html
+++ b/frontend/instances.html
@@ -472,9 +472,61 @@ async function updateSummary(){
     const synerVal=formatNumber(dropValues['synergetic']||0);
     const trashVal=formatNumber(dropValues['trash']||0);
     const rareVal=formatNumber(dropValues['rare']||0);
+    const totalGoldWithDrops=formatNumber(summary.totalGoldWithDrops);
     const day=formatDateTime(summary.sessionStart).split(',')[0];
     const duration=formatDuration(new Date(summary.sessionEnd)-new Date(summary.sessionStart));
-    s.innerHTML=`<div class="summary-grid"><div class="summary-card"><div class="summary-title">EXP</div><div class="summary-value">${formatNumber(summary.totalExp)}</div></div><div class="summary-card"><div class="summary-title">Gold</div><div class="summary-value">${formatNumber(summary.totalGold)}</div></div><div class="summary-card"><div class="summary-title">Psycho</div><div class="summary-value">${formatNumber(summary.totalPsycho)}</div></div><div class="summary-card"><div class="summary-title">Walki</div><div class="summary-value">${formatNumber(summary.fightsCount)}</div></div><div class="summary-card"><div class="summary-title">Czas trwania</div><div class="summary-value">${duration}</div></div></div><div class="summary-group"><h3>Dzień: ${day}</h3></div><div class="summary-grid"><div class="summary-card"><div class="summary-title">Użytkowe <span class="badge bg-light text-dark ms-1">${itemsVal}g</span></div><ul class="item-list">${items}</ul></div><div class="summary-card"><div class="summary-title">Drify <span class="badge bg-light text-dark ms-1">${drifVal}g</span></div><ul class="item-list">${drifs}</ul></div><div class="summary-card"><div class="summary-title">Syngi <span class="badge bg-light text-dark ms-1">${synerVal}g</span></div><ul class="item-list">${syner}</ul></div><div class="summary-card"><div class="summary-title">Śmieci <span class="badge bg-light text-dark ms-1">${trashVal}g</span></div><ul class="item-list">${trash}</ul></div><div class="summary-card"><div class="summary-title">Rary <span class="badge bg-light text-dark ms-1">${rareVal}g</span></div><ul class="item-list">${rare}</ul></div></div>`;
+    s.innerHTML=`
+        <div class="summary-grid">
+            <div class="summary-card">
+                <div class="summary-title">EXP</div>
+                <div class="summary-value">${formatNumber(summary.totalExp)}</div>
+            </div>
+            <div class="summary-card">
+                <div class="summary-title">Gold</div>
+                <div class="summary-value">${formatNumber(summary.totalGold)}</div>
+            </div>
+            <div class="summary-card">
+                <div class="summary-title">Gold łącznie</div>
+                <div class="summary-value">${totalGoldWithDrops}</div>
+            </div>
+            <div class="summary-card">
+                <div class="summary-title">Psycho</div>
+                <div class="summary-value">${formatNumber(summary.totalPsycho)}</div>
+            </div>
+            <div class="summary-card">
+                <div class="summary-title">Walki</div>
+                <div class="summary-value">${formatNumber(summary.fightsCount)}</div>
+            </div>
+            <div class="summary-card">
+                <div class="summary-title">Czas trwania</div>
+                <div class="summary-value">${duration}</div>
+            </div>
+        </div>
+        <div class="summary-group">
+            <h3>Dzień: ${day}</h3>
+        </div>
+        <div class="summary-grid">
+            <div class="summary-card">
+                <div class="summary-title">Użytkowe <span class="badge bg-light text-dark ms-1">${itemsVal}g</span></div>
+                <ul class="item-list">${items}</ul>
+            </div>
+            <div class="summary-card">
+                <div class="summary-title">Drify <span class="badge bg-light text-dark ms-1">${drifVal}g</span></div>
+                <ul class="item-list">${drifs}</ul>
+            </div>
+            <div class="summary-card">
+                <div class="summary-title">Syngi <span class="badge bg-light text-dark ms-1">${synerVal}g</span></div>
+                <ul class="item-list">${syner}</ul>
+            </div>
+            <div class="summary-card">
+                <div class="summary-title">Śmieci <span class="badge bg-light text-dark ms-1">${trashVal}g</span></div>
+                <ul class="item-list">${trash}</ul>
+            </div>
+            <div class="summary-card">
+                <div class="summary-title">Rary <span class="badge bg-light text-dark ms-1">${rareVal}g</span></div>
+                <ul class="item-list">${rare}</ul>
+            </div>
+        </div>`;
 }
 
 function refresh(){loadDays();}

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -82,7 +82,7 @@ form {
 /* Summary */
 .summary-grid {
   display: grid;
-  grid-template-columns: repeat(5, 1fr);
+  grid-template-columns: repeat(6, 1fr);
   gap: 16px;
   max-width: 1400px;
   margin: 0 auto;

--- a/src/Controllers/FightController.cs
+++ b/src/Controllers/FightController.cs
@@ -120,7 +120,8 @@ public class FightsController(AppDbContext db, ILogger<FightsController> logger)
                 synergetics = new List<object>(),
                 trash = new List<object>(),
                 rare = new List<object>(),
-                dropValuesPerType = new Dictionary<string, int>()
+                dropValuesPerType = new Dictionary<string, int>(),
+                totalGoldWithDrops = 0
             });
         }
 
@@ -146,10 +147,13 @@ public class FightsController(AppDbContext db, ILogger<FightsController> logger)
                 g => g.Sum(GetDropValue)
             );
 
+        var totalGoldWithDrops = totalGold + dropValuesPerType.Values.Sum();
+
         return Ok(new
         {
             totalExp,
             totalGold,
+            totalGoldWithDrops,
             totalPsycho,
             fightsCount,
             sessionStart,
@@ -196,7 +200,8 @@ public class FightsController(AppDbContext db, ILogger<FightsController> logger)
                 synergetics = new List<object>(),
                 trash = new List<object>(),
                 rare = new List<object>(),
-                dropValuesPerType = new Dictionary<string, int>()
+                dropValuesPerType = new Dictionary<string, int>(),
+                totalGoldWithDrops = 0
             });
         }
 
@@ -222,10 +227,13 @@ public class FightsController(AppDbContext db, ILogger<FightsController> logger)
                 g => g.Sum(GetDropValue)
             );
 
+        var totalGoldWithDrops = totalGold + dropValuesPerType.Values.Sum();
+
         return Ok(new
         {
             totalExp,
             totalGold,
+            totalGoldWithDrops,
             totalPsycho,
             fightsCount,
             sessionStart,


### PR DESCRIPTION
## Summary
- extend summary calculations with totalGoldWithDrops
- display total gold with drops in frontend summary on fights page and instances page
- update layout to support extra summary card

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856d3ed5728832999013c482c9db18b