### PR TITLE
Fix fight list refresh after instance creation

### DIFF
--- a/frontend/instances.html
+++ b/frontend/instances.html
@@ -450,6 +450,7 @@ document.getElementById('confirmCreateInstance').addEventListener('click',async 
     const modal=bootstrap.Modal.getInstance(modalEl);
     modal.hide();
     clearSelection();
+    delete instanceFights['none'];
     refresh();
 });
 


### PR DESCRIPTION
## Summary
- refresh unassigned fights after creating an instance

## Testing
- `dotnet build` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6856d622ce4c8329b3f964132635d6c7