### PR TITLE
Handle non-boss instances

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -119,6 +119,10 @@ Task task = Task.Run(() =>
             var ctx = scope.ServiceProvider.GetRequiredService<AppDbContext>();
             var repo = new InstanceRepository(ctx);
             var instance = InstanceParser.ToInstanceEntity(timestamp, content);
+            if (instance == null)
+            {
+                return;
+            }
             var last = await repo.GetLastInstanceAsync();
 
             if (last != null && last.EndTime == null && last.Name == instance.Name)

--- a/src/Parser/InstanceParser.cs
+++ b/src/Parser/InstanceParser.cs
@@ -4,16 +4,31 @@ namespace BrokenStatsBackend.src.Parser;
 
 public static class InstanceParser
 {
-    public static InstanceEntity ToInstanceEntity(DateTime timestamp, string raw)
+    public static InstanceEntity? ToInstanceEntity(DateTime timestamp, string raw)
     {
         var parts = raw.Split("[$]");
         if (parts.Length < 2)
             throw new ArgumentException("Invalid instance packet");
 
+        if (parts.Length >= 8 && string.IsNullOrWhiteSpace(parts[7]))
+            return null; // Non-boss instance
+
         if (!long.TryParse(parts[0], out long id))
             throw new ArgumentException("Invalid instance id");
 
         string name = parts[1].Trim('[', ']');
+        if (name.Equals("WIDMOWA HORDA", StringComparison.OrdinalIgnoreCase) && parts.Length >= 10)
+        {
+            string location = parts[9].Trim();
+            if (location.Equals("Miasto Widmowej Hordy", StringComparison.OrdinalIgnoreCase))
+            {
+                name = "IVRAVUL";
+            }
+            else if (location.Equals("Miasto Widmowych Uruków", StringComparison.OrdinalIgnoreCase))
+            {
+                name = "DRAUGUL";
+            }
+        }
         int difficulty = 1;
         if (parts.Length >= 4 && int.TryParse(parts[3], out int d))
             difficulty = d;


### PR DESCRIPTION
## Summary
- filter non-boss instances in parser
- detect extra city info for 'WIDMOWA HORDA' and set name accordingly
- skip adding instance when parser returns `null`

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856e56489d48329af86bc9b0fd08338