### PR TITLE
Add dashboard page with widgets

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -56,6 +56,7 @@ app.UseDefaultFiles(new DefaultFilesOptions { FileProvider = new PhysicalFilePro
 app.UseStaticFiles(new StaticFileOptions { FileProvider = new PhysicalFileProvider(frontendPath) });
 // Serve the main page at / and /instances
 app.MapGet("/instances", () => Results.File(Path.Combine(frontendPath, "index.html"), "text/html"));
+app.MapGet("/dashboard", () => Results.File(Path.Combine(frontendPath, "dashboard.html"), "text/html"));
 app.MapControllers();
 
 var scopeFactory = app.Services.GetRequiredService<IServiceScopeFactory>();

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -1,0 +1,194 @@
+<!DOCTYPE html>
+<html lang="pl">
+<head>
+  <meta charset="UTF-8" />
+  <title>Statystyki</title>
+  <link rel="stylesheet" href="style2.css" />
+  <style>
+    body { align-items: flex-start; gap: 20px; }
+    #sidebar { width: 300px; }
+    #content { flex: 1; display: flex; flex-direction: column; gap: 20px; }
+  </style>
+</head>
+<body>
+  <div id="sidebar" class="fight-sidebar"></div>
+  <div id="content">
+    <div id="summary" class="summary-widget"></div>
+    <div id="instanceStats" class="instance-stats-widget"></div>
+  </div>
+<script>
+const dayInstances = {};
+const instanceFights = {};
+const selectedIds = new Set();
+const instanceDay = {};
+const selectedInstances = new Set();
+const selectedNoneDays = new Set();
+let selectedDay = null;
+
+function pad(n){return n.toString().padStart(2,'0');}
+function formatMMSS(sec){const m=Math.floor(sec/60);const s=sec%60;return `${pad(m)}:${pad(s)}`;}
+function formatNumber(v){return Number(v).toLocaleString();}
+
+async function loadInstanceFights(id){
+  if(instanceFights[id]) return instanceFights[id];
+  const url = id==='none'?'/api/instances/without/fights':`/api/instances/${id}/fights`;
+  const fights = await (await fetch(url)).json();
+  instanceFights[id] = fights;
+  return fights;
+}
+
+function getNoneFightsForDay(date){
+  const all = instanceFights['none'] || [];
+  return all.filter(f=>new Date(f.time).toISOString().split('T')[0]===date);
+}
+
+async function loadDays(){
+  const days = await (await fetch('/api/instances/days')).json();
+  if(!selectedDay && days.length>0) selectedDay = days[0].date;
+  for(const d of days){
+    const list = await (await fetch('/api/instances/byDay?date='+d.date)).json();
+    dayInstances[d.date]=list;
+    list.forEach(i=>instanceDay[i.id]=d.date);
+  }
+  await loadInstanceFights('none');
+  renderSidebar(days);
+  updateSummary();
+}
+
+function renderSidebar(days){
+  const container=document.getElementById('sidebar');
+  container.innerHTML='<h2>Wybierz walki</h2>';
+  days.forEach(d=>{
+    const group=document.createElement('div');
+    group.className='day-group';
+    const header=document.createElement('div');
+    header.className='day-header';
+    const dayCb=document.createElement('input');
+    dayCb.type='checkbox';
+    dayCb.dataset.date=d.date;
+    dayCb.addEventListener('change',()=>toggleDay(d.date,dayCb.checked));
+    const dayLabel=document.createElement('label');
+    dayLabel.textContent=`📅 ${d.date}`;
+    header.appendChild(dayCb);
+    header.appendChild(dayLabel);
+    group.appendChild(header);
+    const list=document.createElement('div');
+    list.className='instance-list';
+    list.id='group-'+d.date.replace(/-/g,'');
+    const noneItem=document.createElement('div');
+    noneItem.className='instance-item';
+    const noneCb=document.createElement('input');
+    noneCb.type='checkbox';
+    noneCb.dataset.id='none';
+    noneCb.addEventListener('change',()=>toggleInstance('none',noneCb.checked));
+    const noneLabel=document.createElement('label');
+    noneLabel.textContent='❌ Bez instancji';
+    noneItem.appendChild(noneCb);noneItem.appendChild(noneLabel);
+    list.appendChild(noneItem);
+    (dayInstances[d.date]||[]).forEach(inst=>{
+      const item=document.createElement('div');
+      item.className='instance-item';
+      const cb=document.createElement('input');
+      cb.type='checkbox';
+      cb.dataset.id=inst.id;
+      cb.addEventListener('change',()=>toggleInstance(inst.id,cb.checked));
+      const lbl=document.createElement('label');
+      lbl.textContent=inst.name;
+      item.appendChild(cb);item.appendChild(lbl);
+      list.appendChild(item);
+    });
+    group.appendChild(list);
+    container.appendChild(group);
+    updateDayState(d.date);
+  });
+}
+
+async function toggleDay(date,state){
+  const list=dayInstances[date]||[];
+  for(const inst of list){ await toggleInstance(inst.id,state,false); }
+  const none=getNoneFightsForDay(date);
+  none.forEach(f=>{if(state) selectedIds.add(f.id.toString()); else selectedIds.delete(f.id.toString());});
+  if(state) selectedNoneDays.add(date); else selectedNoneDays.delete(date);
+  updateDayState(date);
+  updateSummary();
+}
+
+async function toggleInstance(id,state,updateDay=true){
+  const fights=await loadInstanceFights(id);
+  if(id==='none'){
+    const list=getNoneFightsForDay(selectedDay);
+    if(state){list.forEach(f=>selectedIds.add(f.id.toString()));selectedNoneDays.add(selectedDay);}else{list.forEach(f=>selectedIds.delete(f.id.toString()));selectedNoneDays.delete(selectedDay);}    
+  }else{
+    if(state){selectedInstances.add(id);fights.forEach(f=>selectedIds.add(f.id.toString()));}
+    else{selectedInstances.delete(id);fights.forEach(f=>selectedIds.delete(f.id.toString()));}
+    if(updateDay && instanceDay[id]) updateDayState(instanceDay[id]);
+  }
+  updateInstanceState(id);
+  updateSummary();
+}
+
+function updateInstanceState(id){
+  const cb=document.querySelector(`input[data-id="${id}"]`);
+  if(!cb) return;
+  const fights=id==='none'?getNoneFightsForDay(selectedDay):instanceFights[id];
+  if(!fights){cb.checked=false;cb.indeterminate=false;return;}
+  const total=fights.length;
+  if(total===0){cb.checked=false;cb.indeterminate=false;return;}
+  const sel=fights.filter(f=>selectedIds.has(f.id.toString())).length;
+  cb.indeterminate=sel>0 && sel<total;
+  cb.checked=sel===total;
+}
+
+function updateDayState(date){
+  const cb=document.querySelector(`input[data-date="${date}"]`);
+  if(!cb) return;
+  const list=dayInstances[date]||[];
+  const none=getNoneFightsForDay(date);
+  const states=[];
+  if(none.length>0){const sel=none.filter(f=>selectedIds.has(f.id.toString())).length;const total=none.length;states.push(sel===0?0:sel===total?1:0.5);}
+  states.push(...list.map(inst=>{const fights=instanceFights[inst.id];if(!fights) return 0;const sel=fights.filter(f=>selectedIds.has(f.id.toString())).length;const total=fights.length;return sel===0?0:sel===total?1:0.5;}));
+  if(states.every(s=>s===1)) {cb.checked=true;cb.indeterminate=false;}
+  else if(states.every(s=>s===0)) {cb.checked=false;cb.indeterminate=false;}
+  else {cb.checked=false;cb.indeterminate=true;}
+}
+
+async function updateSummary(){
+  const container=document.getElementById('summary');
+  if(selectedIds.size===0){container.innerHTML='<div class="no-fights-card"><p class="no-fights-text">Żadna walka nie została zaznaczona.</p></div>';return;}
+  const res=await fetch('/api/fights/summary',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(Array.from(selectedIds))});
+  const s=await res.json();
+  const card=(title,val)=>`<div class="card"><h3>${title}</h3><div class="value">${val}</div></div>`;
+  const drops=list=>list.map(d=>`<div class="line-item"><span class="label">${d.name}</span><span class="value">${d.count}</span></div>`).join('');
+  container.innerHTML=`
+    <div class="stats-row">
+      ${card('Exp',formatNumber(s.totalExp))}
+      ${card('Psycho',formatNumber(s.totalPsycho))}
+      ${card('Złoto',formatNumber(s.totalGold))}
+      ${card('Zarobek',formatNumber(s.totalGoldWithDrops))}
+      ${card('Walki',formatNumber(s.fightsCount))}
+      ${card('Czas sesji',formatMMSS(Math.floor((new Date(s.sessionEnd)-new Date(s.sessionStart))/1000)))}
+    </div>`;
+}
+
+async function loadStats(){
+  const res=await fetch('/api/instances/stats');
+  const stats=await res.json();
+  const tbody=document.createElement('tbody');
+  stats.forEach(r=>{
+    const tr=document.createElement('tr');
+    tr.innerHTML=`<td>${r.name}</td><td>${r.count}</td><td>${r.avgTime}</td><td>${formatNumber(r.avgGold)}</td><td>${formatNumber(r.avgExp)}</td><td>${formatNumber(r.avgPsycho)}</td>`;
+    tbody.appendChild(tr);
+  });
+  const table=document.createElement('table');
+  table.className='instance-table';
+  table.innerHTML=`<thead><tr><th>Instancja</th><th>Ilość</th><th>Śr. czas</th><th>Śr. złoto</th><th>Śr. exp</th><th>Śr. psycho</th></tr></thead>`;
+  table.appendChild(tbody);
+  document.getElementById('instanceStats').innerHTML='';
+  document.getElementById('instanceStats').appendChild(table);
+}
+
+loadDays();
+loadStats();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create new HTML dashboard combining sidebar, summary and instance stats
- add endpoint to serve per-instance aggregated stats
- map `/dashboard` route to new page

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857f72e5f0483299d098bacf2590f8e