### PR TITLE
Implement difficulty-specific instance stats

### DIFF
--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -185,13 +185,14 @@ async function loadStats(){
   const stats=await res.json();
   const tbody=document.createElement('tbody');
   stats.forEach(r=>{
+    const diffChar=r.difficulty===2?'Ł':r.difficulty===1?'N':'T';
     const tr=document.createElement('tr');
-    tr.innerHTML=`<td>${r.name}</td><td>${r.count}</td><td>${r.avgTime}</td><td>${formatNumber(r.avgGold)}</td><td>${formatNumber(r.avgExp)}</td><td>${formatNumber(r.avgPsycho)}</td>`;
+    tr.innerHTML=`<td>${r.name}</td><td>${diffChar}</td><td>${r.count}</td><td>${r.avgTime}</td><td>${formatNumber(r.avgGold)}</td><td>${formatNumber(r.avgExp)}</td><td>${formatNumber(r.avgPsycho)}</td>`;
     tbody.appendChild(tr);
   });
   const table=document.createElement('table');
   table.className='instance-table';
-  table.innerHTML=`<thead><tr><th>Instancja</th><th>Ilość</th><th>Śr. czas</th><th>Śr. złoto</th><th>Śr. exp</th><th>Śr. psycho</th></tr></thead>`;
+  table.innerHTML=`<thead><tr><th>Instancja</th><th>Poziom</th><th>Ilość</th><th>Śr. czas</th><th>Śr. złoto</th><th>Śr. exp</th><th>Śr. psycho</th></tr></thead>`;
   table.appendChild(tbody);
   document.getElementById('instanceStats').innerHTML='';
   document.getElementById('instanceStats').appendChild(table);

--- a/src/Controllers/InstancesController.cs
+++ b/src/Controllers/InstancesController.cs
@@ -174,6 +174,7 @@ public class InstancesController(AppDbContext db, ILogger<InstancesController> l
             .Join(fightTotals, i => i.Id, f => f.InstanceId, (i, f) => new
             {
                 i.Name,
+                i.Difficulty,
                 Duration = (i.EndTime!.Value - i.StartTime).TotalSeconds,
                 f.Gold,
                 f.Exp,
@@ -182,10 +183,11 @@ public class InstancesController(AppDbContext db, ILogger<InstancesController> l
             .ToList();
 
         var stats = perRun
-            .GroupBy(p => p.Name)
+            .GroupBy(p => new { p.Name, p.Difficulty })
             .Select(g => new
             {
-                name = g.Key,
+                name = g.Key.Name,
+                difficulty = g.Key.Difficulty,
                 count = g.Count(),
                 avgTime = TimeSpan.FromSeconds(g.Average(x => x.Duration)).ToString(@"hh\:mm\:ss"),
                 avgGold = (int)g.Average(x => x.Gold),
@@ -193,6 +195,7 @@ public class InstancesController(AppDbContext db, ILogger<InstancesController> l
                 avgPsycho = (int)g.Average(x => x.Psycho)
             })
             .OrderBy(s => s.name)
+            .ThenBy(s => s.difficulty)
             .ToList();
 
         return Ok(stats);


### PR DESCRIPTION
## Summary
- group instance stats by difficulty level in the backend
- show instance difficulty on the stats dashboard

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858011943a48329b29d2696956d1341