### PR TITLE
Fix instance frame handling

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -126,7 +126,7 @@ Task task = Task.Run(() =>
             }
             var last = await repo.GetLastInstanceAsync();
 
-            if (last != null && last.EndTime == null && last.Name == instance.Name)
+            if (last != null && last.InstanceId == instance.InstanceId)
             {
                 return;
             }

--- a/src/Parser/InstanceParser.cs
+++ b/src/Parser/InstanceParser.cs
@@ -7,13 +7,13 @@ public static class InstanceParser
     public static InstanceEntity? ToInstanceEntity(DateTime timestamp, string raw)
     {
         var parts = raw.Split("[$]");
-        if (parts.Length < 2)
+        if (parts.Length < 5)
             throw new ArgumentException("Invalid instance packet");
 
         if (parts.Length >= 8 && string.IsNullOrWhiteSpace(parts[7]))
             return null; // Non-boss instance
 
-        if (!long.TryParse(parts[0], out long id))
+        if (!long.TryParse(parts[4], out long id))
             throw new ArgumentException("Invalid instance id");
 
         string name = parts[1].Trim('[', ']');


### PR DESCRIPTION
## Summary
- parse instance id from the correct position in instance packet
- ignore instance packets when id repeats

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685810d69a7c8329b367ba1021159cdc