### PR TITLE
Add session dashboard with range view

### DIFF
--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -1,205 +1,102 @@
 <!DOCTYPE html>
 <html lang="pl">
 <head>
-  <meta charset="UTF-8" />
-  <title>Statystyki</title>
-  <link rel="stylesheet" href="style2.css" />
+  <meta charset="UTF-8">
+  <title>Dashboard</title>
+  <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="style2.css">
   <style>
-    body { align-items: flex-start; gap: 20px; }
-    #sidebar { width: 300px; }
-    #content { flex: 1; display: flex; flex-direction: column; gap: 20px; }
+    body{display:flex;flex-direction:column;align-items:center;gap:20px;}
+    .controls{display:flex;gap:10px;margin-bottom:10px;}
+    #details{width:100%;}
+    .back-btn{margin-bottom:10px;}
   </style>
 </head>
 <body>
-  <div id="sidebar" class="fight-sidebar"></div>
-  <div id="content">
-    <div id="summary" class="summary-widget"></div>
-    <div id="instanceStats" class="instance-stats-widget"></div>
+  <div class="controls">
+    <label>Start: <input type="datetime-local" id="start"></label>
+    <label>Koniec: <input type="datetime-local" id="end"></label>
+  </div>
+  <div id="instances"></div>
+  <div id="details" style="display:none;">
+    <button id="backBtn" class="back-btn">Powrót</button>
+    <div id="detailSummary" class="summary-widget"></div>
+    <div id="fights"></div>
   </div>
 <script>
-const dayInstances = {};
-const instanceFights = {};
-const selectedIds = new Set();
-const instanceDay = {};
-const selectedInstances = new Set();
-const selectedNoneDays = new Set();
-let selectedDay = null;
-
+const startInput=document.getElementById('start');
+const endInput=document.getElementById('end');
+const instancesDiv=document.getElementById('instances');
+const detailsDiv=document.getElementById('details');
+const summaryDiv=document.getElementById('detailSummary');
+const fightsDiv=document.getElementById('fights');
+let instanceStarts={};
 function pad(n){return n.toString().padStart(2,'0');}
-function formatMMSS(sec){const m=Math.floor(sec/60);const s=sec%60;return `${pad(m)}:${pad(s)}`;}
-function formatNumber(v){return Number(v).toLocaleString();}
-
-async function loadInstanceFights(id){
-  if(instanceFights[id]) return instanceFights[id];
-  const url = id==='none'?'/api/instances/without/fights':`/api/instances/${id}/fights`;
-  const fights = await (await fetch(url)).json();
-  instanceFights[id] = fights;
-  return fights;
+function formatDate(dt){return `${pad(dt.getDate())}.${pad(dt.getMonth()+1)} ${pad(dt.getHours())}:${pad(dt.getMinutes())}:${pad(dt.getSeconds())}`;}
+function formatDuration(sec){const h=Math.floor(sec/3600);const m=Math.floor((sec%3600)/60);const s=sec%60;return `${pad(h)}:${pad(m)}:${pad(s)}`;}
+function loadInstances(){
+  const from=startInput.value;const to=endInput.value;
+  if(!from||!to)return;
+  fetch(`/api/instances/range?from=${encodeURIComponent(from)}&to=${encodeURIComponent(to)}`)
+    .then(r=>r.json()).then(showInstances);
 }
-
-function getNoneFightsForDay(date){
-  const all = instanceFights['none'] || [];
-  return all.filter(f=>new Date(f.time).toISOString().split('T')[0]===date);
-}
-
-async function loadDays(){
-  const days = await (await fetch('/api/instances/days')).json();
-  if(!selectedDay && days.length>0) selectedDay = days[0].date;
-  for(const d of days){
-    const list = await (await fetch('/api/instances/byDay?date='+d.date)).json();
-    dayInstances[d.date]=list;
-    list.forEach(i=>instanceDay[i.id]=d.date);
-  }
-  await loadInstanceFights('none');
-  renderSidebar(days);
-  updateSummary();
-}
-
-function renderSidebar(days){
-  const container=document.getElementById('sidebar');
-  container.innerHTML='<h2>Wybierz walki</h2>';
-  days.forEach(d=>{
-    const group=document.createElement('div');
-    group.className='day-group';
-    const header=document.createElement('div');
-    header.className='day-header';
-    const dayCb=document.createElement('input');
-    dayCb.type='checkbox';
-    dayCb.dataset.date=d.date;
-    dayCb.addEventListener('change',()=>toggleDay(d.date,dayCb.checked));
-    const dayLabel=document.createElement('label');
-    dayLabel.textContent=`📅 ${d.date}`;
-    header.appendChild(dayCb);
-    header.appendChild(dayLabel);
-    group.appendChild(header);
-    const list=document.createElement('div');
-    list.className='instance-list';
-    list.id='group-'+d.date.replace(/-/g,'');
-    const noneItem=document.createElement('div');
-    noneItem.className='instance-item';
-    const noneCb=document.createElement('input');
-    noneCb.type='checkbox';
-    noneCb.dataset.id='none';
-    noneCb.addEventListener('change',()=>toggleInstance('none',noneCb.checked));
-    const noneLabel=document.createElement('label');
-    noneLabel.textContent='❌ Bez instancji';
-    noneItem.appendChild(noneCb);noneItem.appendChild(noneLabel);
-    list.appendChild(noneItem);
-    (dayInstances[d.date]||[]).forEach(inst=>{
-      const item=document.createElement('div');
-      item.className='instance-item';
-      const cb=document.createElement('input');
-      cb.type='checkbox';
-      cb.dataset.id=inst.id;
-      cb.addEventListener('change',()=>toggleInstance(inst.id,cb.checked));
-      const lbl=document.createElement('label');
-      lbl.textContent=inst.name;
-      item.appendChild(cb);item.appendChild(lbl);
-      list.appendChild(item);
-    });
-    group.appendChild(list);
-    container.appendChild(group);
-    updateDayState(d.date);
-  });
-}
-
-async function toggleDay(date,state){
-  const list=dayInstances[date]||[];
-  for(const inst of list){ await toggleInstance(inst.id,state,false); }
-  const none=getNoneFightsForDay(date);
-  none.forEach(f=>{if(state) selectedIds.add(f.id.toString()); else selectedIds.delete(f.id.toString());});
-  if(state) selectedNoneDays.add(date); else selectedNoneDays.delete(date);
-  updateDayState(date);
-  updateSummary();
-}
-
-async function toggleInstance(id,state,updateDay=true){
-  const fights=await loadInstanceFights(id);
-  if(id==='none'){
-    const list=getNoneFightsForDay(selectedDay);
-    if(state){list.forEach(f=>selectedIds.add(f.id.toString()));selectedNoneDays.add(selectedDay);}else{list.forEach(f=>selectedIds.delete(f.id.toString()));selectedNoneDays.delete(selectedDay);}    
-  }else{
-    if(state){selectedInstances.add(id);fights.forEach(f=>selectedIds.add(f.id.toString()));}
-    else{selectedInstances.delete(id);fights.forEach(f=>selectedIds.delete(f.id.toString()));}
-    if(updateDay && instanceDay[id]) updateDayState(instanceDay[id]);
-  }
-  updateInstanceState(id);
-  updateSummary();
-}
-
-function updateInstanceState(id){
-  const cb=document.querySelector(`input[data-id="${id}"]`);
-  if(!cb) return;
-  const fights=id==='none'?getNoneFightsForDay(selectedDay):instanceFights[id];
-  if(!fights){cb.checked=false;cb.indeterminate=false;return;}
-  const total=fights.length;
-  if(total===0){cb.checked=false;cb.indeterminate=false;return;}
-  const sel=fights.filter(f=>selectedIds.has(f.id.toString())).length;
-  cb.indeterminate=sel>0 && sel<total;
-  cb.checked=sel===total;
-}
-
-function updateDayState(date){
-  const cb=document.querySelector(`input[data-date="${date}"]`);
-  if(!cb) return;
-  const list=dayInstances[date]||[];
-  const none=getNoneFightsForDay(date);
-  const states=[];
-  if(none.length>0){const sel=none.filter(f=>selectedIds.has(f.id.toString())).length;const total=none.length;states.push(sel===0?0:sel===total?1:0.5);}
-  states.push(...list.map(inst=>{const fights=instanceFights[inst.id];if(!fights) return 0;const sel=fights.filter(f=>selectedIds.has(f.id.toString())).length;const total=fights.length;return sel===0?0:sel===total?1:0.5;}));
-  if(states.every(s=>s===1)) {cb.checked=true;cb.indeterminate=false;}
-  else if(states.every(s=>s===0)) {cb.checked=false;cb.indeterminate=false;}
-  else {cb.checked=false;cb.indeterminate=true;}
-}
-
-async function updateSummary(){
-  const container=document.getElementById('summary');
-  if(selectedIds.size===0){container.innerHTML='<div class="no-fights-card"><p class="no-fights-text">Żadna walka nie została zaznaczona.</p></div>';return;}
-  const res=await fetch('/api/fights/summary',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(Array.from(selectedIds))});
-  const s=await res.json();
-  const card=(title,val)=>`<div class="card"><h3>${title}</h3><div class="value">${val}</div></div>`;
-  const drops=list=>list.map(d=>`<div class="line-item"><span class="label">${d.name}</span><span class="value">${formatNumber(d.count)}</span></div>`).join('');
-  const dropVals={};Object.entries(s.dropValuesPerType).forEach(([k,v])=>dropVals[k.toLowerCase()]=v);
-  const dropCard=(title,list,val)=>`<div class="card"><h3>${title}</h3>${drops(list)}<div class="total-value">= ${formatNumber(val)}</div></div>`;
-  container.innerHTML=`
-    <div class="stats-row">
-      ${card('Exp',formatNumber(s.totalExp))}
-      ${card('Psycho',formatNumber(s.totalPsycho))}
-      ${card('Złoto',formatNumber(s.totalGold))}
-      ${card('Zarobek',formatNumber(s.totalGoldWithDrops))}
-      ${card('Walki',formatNumber(s.fightsCount))}
-      ${card('Czas sesji',formatMMSS(Math.floor((new Date(s.sessionEnd)-new Date(s.sessionStart))/1000)))}
-    </div>
-    <div class="drops-grid">
-      ${dropCard('Rary',s.rare,dropVals['rare']||0)}
-      ${dropCard('Użytkowe',s.items,dropVals['item']||0)}
-      ${dropCard('Białe',s.trash,dropVals['trash']||0)}
-      ${dropCard('Syngi',s.synergetics,dropVals['synergetic']||0)}
-      ${dropCard('Drify',s.drifs,dropVals['drif']||0)}
-      ${dropCard('Orby',[],0)}
-    </div>`;
-}
-
-async function loadStats(){
-  const res=await fetch('/api/instances/stats');
-  const stats=await res.json();
+function showInstances(list){
+  instancesDiv.innerHTML='';
+  instanceStarts={};
+  const table=document.createElement('table');
+  table.className='custom-dark-table';
+  table.innerHTML=`<thead><tr><th>Data startu</th><th>Nazwa</th><th>Trudność</th><th>Złoto</th><th>Exp</th><th>Psycho</th><th>Zarobek</th><th>Walki</th><th>Czas trwania</th></tr></thead>`;
   const tbody=document.createElement('tbody');
-  stats.forEach(r=>{
-    const diffChar=r.difficulty===2?'Ł':r.difficulty===1?'N':'T';
+  list.forEach(inst=>{
+    instanceStarts[inst.id]=inst.startTime;
+    const diff=inst.difficulty===2?'Ł':inst.difficulty===1?'N':'T';
     const tr=document.createElement('tr');
-    tr.innerHTML=`<td>${r.name}</td><td>${diffChar}</td><td>${r.count}</td><td>${r.avgTime}</td><td>${formatNumber(r.avgGold)}</td><td>${formatNumber(r.avgExp)}</td><td>${formatNumber(r.avgPsycho)}</td>`;
+    const dur=inst.durationSeconds!=null?formatDuration(inst.durationSeconds):`<button data-id="${inst.id}" class="close">zakończ instancję</button>`;
+    tr.innerHTML=`<td>${formatDate(new Date(inst.startTime))}</td><td>${inst.name}</td><td>${diff}</td><td>${inst.gold.toLocaleString()}</td><td>${inst.exp.toLocaleString()}</td><td>${inst.psycho.toLocaleString()}</td><td>${inst.profit.toLocaleString()}</td><td>${inst.fights}</td><td>${dur}</td>`;
+    tr.dataset.id=inst.id;
     tbody.appendChild(tr);
   });
-  const table=document.createElement('table');
-  table.className='instance-table';
-  table.innerHTML=`<thead><tr><th>Instancja</th><th>Poziom</th><th>Ilość</th><th>Śr. czas</th><th>Śr. złoto</th><th>Śr. exp</th><th>Śr. psycho</th></tr></thead>`;
   table.appendChild(tbody);
-  document.getElementById('instanceStats').innerHTML='';
-  document.getElementById('instanceStats').appendChild(table);
+  instancesDiv.appendChild(table);
+  tbody.querySelectorAll('button.close').forEach(btn=>btn.addEventListener('click',e=>{e.stopPropagation();closeInstance(btn.dataset.id);}));
+  tbody.querySelectorAll('tr').forEach(tr=>tr.addEventListener('click',e=>{if(e.target.tagName==='BUTTON')return;showDetails(tr.dataset.id);}));
 }
-
-loadDays();
-loadStats();
+function closeInstance(id){
+  fetch(`/api/instances/${id}/close`,{method:'POST'}).then(()=>loadInstances());
+}
+function showDetails(id){
+  const start=instanceStarts[id];
+  if(!start)return;
+  fetch(`/api/instances/${id}/fights`).then(r=>r.json()).then(list=>{
+    const ids=list.map(f=>f.id);
+    fetch('/api/fights/summary',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(ids)})
+      .then(r=>r.json()).then(s=>renderSummary(s));
+    const table=document.createElement('table');
+    table.className='custom-dark-table';
+    table.innerHTML=`<thead><tr><th>Data</th><th>Złoto</th><th>Exp</th><th>Psycho</th><th>Przeciwnicy</th><th>Drop</th></tr></thead>`;
+    const tbody=document.createElement('tbody');
+    list.forEach(f=>{
+      const time=new Date(new Date(start).getTime()+f.offsetSeconds*1000);
+      const tr=document.createElement('tr');
+      tr.innerHTML=`<td>${formatDate(time)}</td><td>${f.gold}</td><td>${f.exp}</td><td>${f.psycho}</td><td>${f.opponents}</td><td>${f.drops}</td>`;
+      tbody.appendChild(tr);
+    });
+    table.appendChild(tbody);
+    fightsDiv.innerHTML='';
+    fightsDiv.appendChild(table);
+    instancesDiv.style.display='none';
+    detailsDiv.style.display='block';
+  });
+}
+function renderSummary(s){
+  const card=(t,v)=>`<div class="card"><h3>${t}</h3><div class="value">${v}</div></div>`;
+  const drops=list=>list.map(d=>`<div class="line-item"><span class="label">${d.name}</span><span class="value">${d.count.toLocaleString()}</span></div>`).join('');
+  const dropVals={};Object.entries(s.dropValuesPerType).forEach(([k,v])=>dropVals[k.toLowerCase()]=v);
+  const dropCard=(t,l,v)=>`<div class="card"><h3>${t}</h3>${drops(l)}<div class="total-value">= ${v.toLocaleString()}</div></div>`;
+  summaryDiv.innerHTML=`<div class="stats-row">${card('Exp',s.totalExp.toLocaleString())}${card('Psycho',s.totalPsycho.toLocaleString())}${card('Złoto',s.totalGold.toLocaleString())}${card('Zarobek',s.totalGoldWithDrops.toLocaleString())}${card('Walki',s.fightsCount.toLocaleString())}${card('Czas',formatDuration(Math.floor((new Date(s.sessionEnd)-new Date(s.sessionStart))/1000)))}</div><div class="drops-grid">${dropCard('Rary',s.rare,dropVals['rare']||0)}${dropCard('Użytkowe',s.items,dropVals['item']||0)}${dropCard('Białe',s.trash,dropVals['trash']||0)}${dropCard('Syngi',s.synergetics,dropVals['synergetic']||0)}${dropCard('Drify',s.drifs,dropVals['drif']||0)}${dropCard('Orby',[],0)}</div>`;
+}
+document.getElementById('backBtn').addEventListener('click',()=>{detailsDiv.style.display='none';instancesDiv.style.display='block';});
+const now=new Date();endInput.value=now.toISOString().slice(0,16);const start=new Date(now.getTime()-3600000);startInput.value=start.toISOString().slice(0,16);startInput.addEventListener('change',loadInstances);endInput.addEventListener('change',loadInstances);loadInstances();
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add API endpoints to close any instance and fetch instances by time range
- redesign dashboard to list instances in a range
- show fights and summary for a selected instance

## Testing
- `dotnet build --no-restore` *(fails: command not found)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685833e19a288329b34a8cbd4897418b