### PR TITLE
Improve dashboard navigation and unify styles

### DIFF
--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -9,23 +9,25 @@
     body{display:flex;flex-direction:column;align-items:center;gap:20px;}
     .controls{display:flex;gap:10px;margin-bottom:10px;}
     #details{width:100%;}
-    .back-btn{margin-bottom:10px;}
   </style>
 </head>
 <body>
   <div class="controls">
-    <label>Start: <input type="datetime-local" id="start"></label>
-    <label>Koniec: <input type="datetime-local" id="end"></label>
+    <label id="startLabel">Start: <input type="datetime-local" id="start"></label>
+    <label id="endLabel">Koniec: <input type="datetime-local" id="end"></label>
+    <button id="backBtn" class="back-button" style="display:none;">Powrót</button>
   </div>
   <div id="instances"></div>
   <div id="details" style="display:none;">
-    <button id="backBtn" class="back-btn">Powrót</button>
     <div id="detailSummary" class="summary-widget"></div>
     <div id="fights"></div>
   </div>
 <script>
 const startInput=document.getElementById('start');
 const endInput=document.getElementById('end');
+const startLabel=document.getElementById('startLabel');
+const endLabel=document.getElementById('endLabel');
+const backBtn=document.getElementById('backBtn');
 const instancesDiv=document.getElementById('instances');
 const detailsDiv=document.getElementById('details');
 const summaryDiv=document.getElementById('detailSummary');
@@ -51,7 +53,7 @@ function showInstances(list){
     instanceStarts[inst.id]=inst.startTime;
     const diff=inst.difficulty===2?'Ł':inst.difficulty===1?'N':'T';
     const tr=document.createElement('tr');
-    const dur=inst.durationSeconds!=null?formatDuration(inst.durationSeconds):`<button data-id="${inst.id}" class="close">zakończ instancję</button>`;
+    const dur=inst.durationSeconds!=null?formatDuration(inst.durationSeconds):`<button data-id="${inst.id}" class="close end-button">zakończ instancję</button>`;
     tr.innerHTML=`<td>${formatDate(new Date(inst.startTime))}</td><td>${inst.name}</td><td>${diff}</td><td>${inst.gold.toLocaleString()}</td><td>${inst.exp.toLocaleString()}</td><td>${inst.psycho.toLocaleString()}</td><td>${inst.profit.toLocaleString()}</td><td>${inst.fights}</td><td>${dur}</td>`;
     tr.dataset.id=inst.id;
     tbody.appendChild(tr);
@@ -86,6 +88,9 @@ function showDetails(id){
     fightsDiv.appendChild(table);
     instancesDiv.style.display='none';
     detailsDiv.style.display='block';
+    startLabel.style.display='none';
+    endLabel.style.display='none';
+    backBtn.style.display='inline-block';
   });
 }
 function renderSummary(s){
@@ -95,7 +100,13 @@ function renderSummary(s){
   const dropCard=(t,l,v)=>`<div class="card"><h3>${t}</h3>${drops(l)}<div class="total-value">= ${v.toLocaleString()}</div></div>`;
   summaryDiv.innerHTML=`<div class="stats-row">${card('Exp',s.totalExp.toLocaleString())}${card('Psycho',s.totalPsycho.toLocaleString())}${card('Złoto',s.totalGold.toLocaleString())}${card('Zarobek',s.totalGoldWithDrops.toLocaleString())}${card('Walki',s.fightsCount.toLocaleString())}${card('Czas',formatDuration(Math.floor((new Date(s.sessionEnd)-new Date(s.sessionStart))/1000)))}</div><div class="drops-grid">${dropCard('Rary',s.rare,dropVals['rare']||0)}${dropCard('Użytkowe',s.items,dropVals['item']||0)}${dropCard('Białe',s.trash,dropVals['trash']||0)}${dropCard('Syngi',s.synergetics,dropVals['synergetic']||0)}${dropCard('Drify',s.drifs,dropVals['drif']||0)}${dropCard('Orby',[],0)}</div>`;
 }
-document.getElementById('backBtn').addEventListener('click',()=>{detailsDiv.style.display='none';instancesDiv.style.display='block';});
+backBtn.addEventListener('click',()=>{
+  detailsDiv.style.display='none';
+  instancesDiv.style.display='block';
+  startLabel.style.display='inline-block';
+  endLabel.style.display='inline-block';
+  backBtn.style.display='none';
+});
 const now=new Date();endInput.value=now.toISOString().slice(0,16);const start=new Date(now.getTime()-3600000);startInput.value=start.toISOString().slice(0,16);startInput.addEventListener('change',loadInstances);endInput.addEventListener('change',loadInstances);loadInstances();
 </script>
 </body>

--- a/frontend/session.html
+++ b/frontend/session.html
@@ -15,7 +15,7 @@
   <div id="content">
     <div class="session-controls">
       <label>Start sesji: <input type="datetime-local" id="sessionStart"></label>
-      <button id="closeInstance">Zamknij instancję</button>
+      <button id="closeInstance" class="end-button">Zamknij instancję</button>
     </div>
     <div id="summary" class="summary-widget"></div>
   </div>

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -1,19 +1,20 @@
 /* Spójne tło dla całości */
 body {
-  background-color: #121212;
-  color: #f0f0f0;
-  font-family: "Segoe UI", sans-serif;
+  background-color: #111;
+  color: #eee;
+  font-family: 'Segoe UI', sans-serif;
   padding: 20px;
+  font-size: 13px;
+  max-width: 1000px;
+  margin: auto;
 }
 
 /* Nagłówek */
 h1 {
+  font-size: 22px;
+  margin-bottom: 20px;
+  color: #fff;
   text-align: center;
-  margin-bottom: 32px;
-  font-size: 2.2rem;
-  font-weight: 600;
-  color: #ffffff;
-  text-shadow: 0 2px 4px rgba(0, 0, 0, 0.4);
 }
 
 
@@ -104,27 +105,21 @@ h1 {
 }
 .custom-dark-table {
   width: 100%;
-  max-width: 1400px;
-  margin: 0 auto;
   border-collapse: collapse;
-  background-color: #1e1e1e; /* ciemne tło jak summary/form */
-  color: #ddd;
-  border-radius: 12px;
+  background-color: #1b1b1b;
+  border-radius: 6px;
   overflow: hidden;
-  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.4);
+  margin-top: 10px;
 }
 
 .custom-dark-table thead {
-  background-color: #2a2a2a;
+  background-color: #222;
 }
 
 .custom-dark-table thead th {
-  padding: 12px;
+  padding: 10px;
   text-align: left;
-  font-weight: 600;
-  text-transform: uppercase;
-  font-size: 12px;
-  border-bottom: 1px solid #444;
+  border-bottom: 1px solid #333;
   color: #ccc;
 }
 
@@ -133,7 +128,8 @@ h1 {
 }
 
 .custom-dark-table tbody tr:hover {
-  background-color: #2e2e2e;
+  background-color: #2a2a2a;
+  cursor: pointer;
 }
 
 .custom-dark-table tbody tr.selected {
@@ -141,9 +137,10 @@ h1 {
 }
 
 .custom-dark-table td {
-  padding: 10px 12px;
+  padding: 10px;
+  text-align: left;
   border-bottom: 1px solid #333;
-  vertical-align: middle;
+  color: #eee;
 }
 
 .custom-dark-table input[type="checkbox"] {
@@ -213,4 +210,28 @@ h1 {
 }
 .day-list li.selected, .instance-list li.selected {
   background-color: #0066cc;
+}
+
+.back-button {
+  background-color: #333;
+  color: #eee;
+  padding: 8px 16px;
+  border: none;
+  border-radius: 5px;
+  cursor: pointer;
+  margin-bottom: 20px;
+}
+
+.end-button {
+  background-color: #c62828;
+  color: #fff;
+  border: none;
+  padding: 6px 10px;
+  font-size: 12px;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.end-button:hover {
+  background-color: #e53935;
 }

--- a/frontend/style2.css
+++ b/frontend/style2.css
@@ -3,19 +3,21 @@ body {
   color: #eee;
   font-family: 'Segoe UI', sans-serif;
   padding: 20px;
-  font-size: 12px;
-  display: flex;
-  justify-content: center;
+  font-size: 13px;
+  max-width: 1000px;
+  margin: auto;
 }
 
 .summary-widget {
   max-width: 1000px;
   width: 100%;
+  margin: auto;
+  margin-bottom: 20px;
 }
 
 h1 {
-  font-size: 20px;
-  margin-bottom: 16px;
+  font-size: 22px;
+  margin-bottom: 20px;
   color: #fff;
   text-align: center;
 }
@@ -105,8 +107,8 @@ body {
   font-family: 'Segoe UI', sans-serif;
   padding: 20px;
   font-size: 13px;
-  display: flex;
-  justify-content: center;
+  max-width: 1000px;
+  margin: auto;
 }
 
 .instance-stats-widget {
@@ -115,8 +117,8 @@ body {
 }
 
 h1 {
-  font-size: 20px;
-  margin-bottom: 16px;
+  font-size: 22px;
+  margin-bottom: 20px;
   color: #fff;
   text-align: center;
 }
@@ -127,6 +129,7 @@ h1 {
   background-color: #1b1b1b;
   border-radius: 6px;
   overflow: hidden;
+  margin-top: 10px;
 }
 
 .instance-table th,
@@ -146,6 +149,35 @@ h1 {
   color: #eee;
 }
 
+.instance-table tr:hover {
+  background-color: #2a2a2a;
+  cursor: pointer;
+}
+
 .instance-table tr:last-child td {
   border-bottom: none;
+}
+
+.back-button {
+  background-color: #333;
+  color: #eee;
+  padding: 8px 16px;
+  border: none;
+  border-radius: 5px;
+  cursor: pointer;
+  margin-bottom: 20px;
+}
+
+.end-button {
+  background-color: #c62828;
+  color: #fff;
+  border: none;
+  padding: 6px 10px;
+  font-size: 12px;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.end-button:hover {
+  background-color: #e53935;
 }


### PR DESCRIPTION
## Summary
- adjust base page and table styles
- provide styles for back and end buttons
- move back button to header on dashboard and toggle controls visibility
- style close buttons

## Testing
- `dotnet test` *(fails: dotnet not installed)*
- `npm test` *(fails: no `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_685837038ef4832983b733d3764e10a3