### PR TITLE
Wrap dashboard script in DOMContentLoaded

### DIFF
--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -27,6 +27,7 @@
     <div id="fights"></div>
   </div>
 <script>
+document.addEventListener('DOMContentLoaded',()=>{
 const startInput=document.getElementById('start');
 const endInput=document.getElementById('end');
 const startLabel=document.getElementById('startLabel');
@@ -263,6 +264,7 @@ deleteBtn.addEventListener('click',async ()=>{
   await fetch(`/api/instances/${id}`,{method:'DELETE'});
   backBtn.click();
   loadInstances();
+});
 });
 </script>
 <div class="modal" id="createInstanceModal" tabindex="-1">


### PR DESCRIPTION
## Summary
- wrap dashboard script body in `DOMContentLoaded` handler

## Testing
- `dotnet build BrokenStatsBackend.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68587c6ea4708329abdf507048c2608c