### PR TITLE
Fix closing instance times

### DIFF
--- a/src/Controllers/InstancesController.cs
+++ b/src/Controllers/InstancesController.cs
@@ -271,7 +271,7 @@ public class InstancesController(AppDbContext db, ILogger<InstancesController> l
     public async Task<IActionResult> CloseLastInstance()
     {
         var repo = new InstanceRepository(_db);
-        await repo.SetLastInstanceEndTimeAsync(DateTime.UtcNow);
+        await repo.SetLastInstanceEndTimeAsync(DateTime.Now);
         return Ok();
     }
 
@@ -282,7 +282,7 @@ public class InstancesController(AppDbContext db, ILogger<InstancesController> l
         if (instance == null) return NotFound();
         if (instance.EndTime == null)
         {
-            instance.EndTime = DateTime.UtcNow;
+            instance.EndTime = DateTime.Now;
             await _db.SaveChangesAsync();
         }
         return Ok();


### PR DESCRIPTION
## Summary
- use local time instead of UTC when closing instances

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68587c7133b883299d83803b588f84f1