### PR TITLE
Fix environment exception handling

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -45,7 +45,14 @@ app.Use(async (context, next) =>
         throw;
     }
 });
-app.UseDeveloperExceptionPage();
+if (builder.Environment.IsDevelopment())
+{
+    app.UseDeveloperExceptionPage();
+}
+else
+{
+    app.UseExceptionHandler("/error");
+}
 
 
 app.Map("/error", () => Results.Problem("An error occurred."));


### PR DESCRIPTION
## Summary
- ensure `UseDeveloperExceptionPage` runs only in development
- fall back to `/error` handler in other environments

## Testing
- `dotnet build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68587c766a04832983d7725861c40acb