### PR TITLE
Add stats page

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -67,6 +67,8 @@ app.UseDefaultFiles(new DefaultFilesOptions
 app.UseStaticFiles(new StaticFileOptions { FileProvider = new PhysicalFileProvider(frontendPath) });
 // Serve dashboard also under /dashboard for backwards compatibility
 app.MapGet("/dashboard", () => Results.File(Path.Combine(frontendPath, "dashboard.html"), "text/html"));
+// Stats page
+app.MapGet("/stats", () => Results.File(Path.Combine(frontendPath, "stats.html"), "text/html"));
 app.MapControllers();
 
 var scopeFactory = app.Services.GetRequiredService<IServiceScopeFactory>();

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -16,6 +16,7 @@
     <label id="startLabel">Start: <input type="datetime-local" id="start"></label>
     <label id="endLabel">Koniec: <input type="datetime-local" id="end"></label>
     <button id="todayBtn" class="back-button">Dzisiaj</button>
+    <button id="statsBtn" class="back-button">Statystyki</button>
     <button id="backBtn" class="back-button" style="display:none;">Powrót</button>
     <button id="createBtn" class="end-button" style="display:none;">Stwórz instancję</button>
     <button id="deleteBtn" class="end-button" style="display:none;">Usuń instancję</button>
@@ -33,6 +34,7 @@ const endInput=document.getElementById('end');
 const startLabel=document.getElementById('startLabel');
 const endLabel=document.getElementById('endLabel');
 const todayBtn=document.getElementById('todayBtn');
+const statsBtn=document.getElementById('statsBtn');
 const backBtn=document.getElementById('backBtn');
 const createBtn=document.getElementById('createBtn');
 const deleteBtn=document.getElementById('deleteBtn');
@@ -290,6 +292,9 @@ todayBtn.addEventListener('click',()=>{
   setDefaultRange();
   saveRange();
   loadInstances();
+});
+statsBtn.addEventListener('click',()=>{
+  window.location.href='stats.html';
 });
 
 function openCreateInstanceModal(){

--- a/frontend/stats.html
+++ b/frontend/stats.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="pl">
+<head>
+  <meta charset="UTF-8">
+  <title>Statystyki Instancji</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body{display:flex;flex-direction:column;align-items:center;gap:20px;}
+    .controls{display:flex;gap:10px;margin-bottom:10px;justify-content:center;align-items:center;}
+    .sticky-controls{position:sticky;top:0;z-index:100;background-color:#121212;padding:10px;width:100%;}
+  </style>
+</head>
+<body>
+  <div class="controls sticky-controls">
+    <button id="backDashboardBtn" class="back-button">Powrót</button>
+  </div>
+  <div id="statsTableContainer" style="width:100%;"></div>
+<script>
+document.addEventListener('DOMContentLoaded',()=>{
+  document.getElementById('backDashboardBtn').addEventListener('click',()=>{
+    window.location.href='dashboard.html';
+  });
+  fetch('/api/instances/stats').then(r=>r.json()).then(showStats);
+  function showStats(list){
+    const table=document.createElement('table');
+    table.className='custom-dark-table';
+    table.innerHTML=`<thead><tr><th>Nazwa</th><th>Trudność</th><th>Ilość</th><th>Śr. czas</th><th>Śr. złoto</th><th>Śr. exp</th><th>Śr. psycho</th><th>Śr. zysk</th></tr></thead>`;
+    const tbody=document.createElement('tbody');
+    list.forEach(s=>{
+      const diff=s.difficulty===3?'Trudna':s.difficulty===1?'Normalna':'Łatwa';
+      const tr=document.createElement('tr');
+      tr.innerHTML=`<td>${s.name}</td><td>${diff}</td><td>${s.count}</td><td>${s.avgTime}</td><td>${s.avgGold.toLocaleString()}</td><td>${s.avgExp.toLocaleString()}</td><td>${s.avgPsycho.toLocaleString()}</td><td>${s.avgProfit.toLocaleString()}</td>`;
+      tbody.appendChild(tr);
+    });
+    table.appendChild(tbody);
+    document.getElementById('statsTableContainer').appendChild(table);
+  }
+});
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `stats.html` page showing average results for each instance type
- link the new page via a "Statystyki" button on the dashboard
- map `/stats` route to serve the new page

## Testing
- `dotnet build --no-restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685928d798608329a45f776c26b32f2b