### PR TITLE
Add local backend service option

### DIFF
--- a/BrokenStatsBackend.sln
+++ b/BrokenStatsBackend.sln
@@ -4,6 +4,8 @@ VisualStudioVersion = 17.5.2.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BrokenStatsBackend", "BrokenStatsBackend.csproj", "{5ADA2BB6-BD8A-FBBA-631C-E748BB1D8E69}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WinFormsFrontend", "WinFormsFrontend\WinFormsFrontend.csproj", "{531ECE1B-334D-4B94-8F00-BCA5E7D5D62F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -14,10 +16,10 @@ Global
                 {5ADA2BB6-BD8A-FBBA-631C-E748BB1D8E69}.Debug|Any CPU.Build.0 = Debug|Any CPU
                 {5ADA2BB6-BD8A-FBBA-631C-E748BB1D8E69}.Release|Any CPU.ActiveCfg = Release|Any CPU
                 {5ADA2BB6-BD8A-FBBA-631C-E748BB1D8E69}.Release|Any CPU.Build.0 = Release|Any CPU
-                {F94DD1FE-ABF7-4B4E-86DD-1CBBF188EF72}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-                {F94DD1FE-ABF7-4B4E-86DD-1CBBF188EF72}.Debug|Any CPU.Build.0 = Debug|Any CPU
-                {F94DD1FE-ABF7-4B4E-86DD-1CBBF188EF72}.Release|Any CPU.ActiveCfg = Release|Any CPU
-                {F94DD1FE-ABF7-4B4E-86DD-1CBBF188EF72}.Release|Any CPU.Build.0 = Release|Any CPU
+                {531ECE1B-334D-4B94-8F00-BCA5E7D5D62F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {531ECE1B-334D-4B94-8F00-BCA5E7D5D62F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {531ECE1B-334D-4B94-8F00-BCA5E7D5D62F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {531ECE1B-334D-4B94-8F00-BCA5E7D5D62F}.Release|Any CPU.Build.0 = Release|Any CPU
         EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/WinFormsFrontend/Dtos.cs
+++ b/WinFormsFrontend/Dtos.cs
@@ -1,0 +1,27 @@
+namespace BrokenStatsFrontendWinForms;
+
+public class InstanceDto
+{
+    public int id { get; set; }
+    public DateTime startTime { get; set; }
+    public string name { get; set; } = string.Empty;
+    public int difficulty { get; set; }
+    public int gold { get; set; }
+    public int exp { get; set; }
+    public int psycho { get; set; }
+    public int profit { get; set; }
+    public int fights { get; set; }
+    public int? durationSeconds { get; set; }
+}
+
+public class InstanceFightDto
+{
+    public Guid id { get; set; }
+    public int offsetSeconds { get; set; }
+    public int exp { get; set; }
+    public int gold { get; set; }
+    public int psycho { get; set; }
+    public int dropValue { get; set; }
+    public string opponents { get; set; } = string.Empty;
+    public string drops { get; set; } = string.Empty;
+}

--- a/WinFormsFrontend/MainForm.Designer.cs
+++ b/WinFormsFrontend/MainForm.Designer.cs
@@ -1,0 +1,91 @@
+namespace BrokenStatsFrontendWinForms
+{
+    partial class MainForm
+    {
+        private System.ComponentModel.IContainer components = null;
+        private System.Windows.Forms.DateTimePicker startPicker;
+        private System.Windows.Forms.DateTimePicker endPicker;
+        private System.Windows.Forms.Button loadButton;
+        private System.Windows.Forms.DataGridView instancesGrid;
+        private System.Windows.Forms.DataGridView fightsGrid;
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        private void InitializeComponent()
+        {
+            this.startPicker = new System.Windows.Forms.DateTimePicker();
+            this.endPicker = new System.Windows.Forms.DateTimePicker();
+            this.loadButton = new System.Windows.Forms.Button();
+            this.instancesGrid = new System.Windows.Forms.DataGridView();
+            this.fightsGrid = new System.Windows.Forms.DataGridView();
+            ((System.ComponentModel.ISupportInitialize)(this.instancesGrid)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.fightsGrid)).BeginInit();
+            this.SuspendLayout();
+            // 
+            // startPicker
+            // 
+            this.startPicker.CustomFormat = "yyyy-MM-dd HH:mm:ss";
+            this.startPicker.Format = System.Windows.Forms.DateTimePickerFormat.Custom;
+            this.startPicker.Location = new System.Drawing.Point(12, 12);
+            this.startPicker.Size = new System.Drawing.Size(200, 23);
+            // 
+            // endPicker
+            // 
+            this.endPicker.CustomFormat = "yyyy-MM-dd HH:mm:ss";
+            this.endPicker.Format = System.Windows.Forms.DateTimePickerFormat.Custom;
+            this.endPicker.Location = new System.Drawing.Point(218, 12);
+            this.endPicker.Size = new System.Drawing.Size(200, 23);
+            // 
+            // loadButton
+            // 
+            this.loadButton.Location = new System.Drawing.Point(424, 12);
+            this.loadButton.Size = new System.Drawing.Size(75, 23);
+            this.loadButton.Text = "Load";
+            this.loadButton.Click += new System.EventHandler(this.loadButton_Click);
+            // 
+            // instancesGrid
+            // 
+            this.instancesGrid.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.instancesGrid.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
+            this.instancesGrid.Location = new System.Drawing.Point(12, 41);
+            this.instancesGrid.MultiSelect = false;
+            this.instancesGrid.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.FullRowSelect;
+            this.instancesGrid.Size = new System.Drawing.Size(760, 200);
+            this.instancesGrid.SelectionChanged += new System.EventHandler(this.instancesGrid_SelectionChanged);
+            // 
+            // fightsGrid
+            // 
+            this.fightsGrid.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.fightsGrid.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
+            this.fightsGrid.Location = new System.Drawing.Point(12, 247);
+            this.fightsGrid.MultiSelect = false;
+            this.fightsGrid.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.FullRowSelect;
+            this.fightsGrid.Size = new System.Drawing.Size(760, 200);
+            // 
+            // MainForm
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
+            this.ClientSize = new System.Drawing.Size(784, 461);
+            this.Controls.Add(this.startPicker);
+            this.Controls.Add(this.endPicker);
+            this.Controls.Add(this.loadButton);
+            this.Controls.Add(this.instancesGrid);
+            this.Controls.Add(this.fightsGrid);
+            this.Name = "MainForm";
+            this.Text = "BrokenStats Dashboard";
+            ((System.ComponentModel.ISupportInitialize)(this.instancesGrid)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.fightsGrid)).EndInit();
+            this.ResumeLayout(false);
+        }
+    }
+}

--- a/WinFormsFrontend/MainForm.cs
+++ b/WinFormsFrontend/MainForm.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+using BrokenStatsFrontendWinForms.Services;
+
+namespace BrokenStatsFrontendWinForms
+{
+    public partial class MainForm : Form
+    {
+        private readonly IBackendService _backend;
+
+        public MainForm(IBackendService backend)
+        {
+            _backend = backend;
+            InitializeComponent();
+        }
+
+        private async void loadButton_Click(object sender, EventArgs e)
+        {
+            await LoadInstancesAsync();
+        }
+
+        private async Task LoadInstancesAsync()
+        {
+            var from = startPicker.Value;
+            var to = endPicker.Value;
+            try
+            {
+                var list = await _backend.GetInstancesAsync(from, to);
+                instancesGrid.DataSource = list;
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show(ex.Message, "Error");
+            }
+        }
+
+        private async void instancesGrid_SelectionChanged(object sender, EventArgs e)
+        {
+            if (instancesGrid.CurrentRow?.DataBoundItem is InstanceDto inst)
+            {
+                try
+                {
+                    var list = await _backend.GetFightsAsync(inst.id);
+                    fightsGrid.DataSource = list;
+                }
+                catch (Exception ex)
+                {
+                    MessageBox.Show(ex.Message, "Error");
+                }
+            }
+        }
+    }
+
+}

--- a/WinFormsFrontend/Program.cs
+++ b/WinFormsFrontend/Program.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Windows.Forms;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.EntityFrameworkCore;
+using BrokenStatsBackend.src.Database;
+using BrokenStatsFrontendWinForms.Services;
+
+namespace BrokenStatsFrontendWinForms
+{
+    internal static class Program
+    {
+        [STAThread]
+        static void Main()
+        {
+            var services = new ServiceCollection();
+            services.AddDbContext<AppDbContext>(options =>
+                options.UseSqlite("Data Source=data/data.db"));
+            services.AddHttpClient<HttpBackendService>(c => c.BaseAddress = new Uri("http://localhost:5005"));
+            services.AddTransient<LocalBackendService>();
+            services.AddTransient<IBackendService>(sp =>
+            {
+                return Environment.GetEnvironmentVariable("LOCAL_BACKEND") == "1"
+                    ? sp.GetRequiredService<LocalBackendService>()
+                    : sp.GetRequiredService<HttpBackendService>();
+            });
+            services.AddTransient<MainForm>();
+
+            using var provider = services.BuildServiceProvider();
+
+            Application.EnableVisualStyles();
+            Application.SetCompatibleTextRenderingDefault(false);
+
+            var form = provider.GetRequiredService<MainForm>();
+            Application.Run(form);
+        }
+    }
+}

--- a/WinFormsFrontend/Services/HttpBackendService.cs
+++ b/WinFormsFrontend/Services/HttpBackendService.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+
+namespace BrokenStatsFrontendWinForms.Services;
+
+public class HttpBackendService(HttpClient client) : IBackendService
+{
+    private readonly HttpClient _client = client;
+
+    public async Task<List<InstanceDto>> GetInstancesAsync(DateTime from, DateTime to)
+    {
+        var url = $"/api/instances/range?from={from:o}&to={to:o}";
+        return await _client.GetFromJsonAsync<List<InstanceDto>>(url) ?? new();
+    }
+
+    public async Task<List<InstanceFightDto>> GetFightsAsync(int instanceId)
+    {
+        var url = $"/api/instances/{instanceId}/fights";
+        return await _client.GetFromJsonAsync<List<InstanceFightDto>>(url) ?? new();
+    }
+}

--- a/WinFormsFrontend/Services/IBackendService.cs
+++ b/WinFormsFrontend/Services/IBackendService.cs
@@ -1,0 +1,11 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace BrokenStatsFrontendWinForms.Services;
+
+public interface IBackendService
+{
+    Task<List<InstanceDto>> GetInstancesAsync(DateTime from, DateTime to);
+    Task<List<InstanceFightDto>> GetFightsAsync(int instanceId);
+}

--- a/WinFormsFrontend/Services/LocalBackendService.cs
+++ b/WinFormsFrontend/Services/LocalBackendService.cs
@@ -1,0 +1,111 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using BrokenStatsBackend.src.Database;
+using BrokenStatsBackend.src.Controllers;
+
+namespace BrokenStatsFrontendWinForms.Services;
+
+public class LocalBackendService(AppDbContext db) : IBackendService
+{
+    private readonly AppDbContext _db = db;
+
+    public async Task<List<InstanceDto>> GetInstancesAsync(DateTime from, DateTime to)
+    {
+        var instances = await _db.Instances
+            .Where(i => i.StartTime >= from && i.StartTime <= to)
+            .OrderByDescending(i => i.StartTime)
+            .ToListAsync();
+
+        var ids = instances.Select(i => i.Id).ToList();
+
+        var fights = await _db.Fights
+            .Where(f => f.InstanceId != null && ids.Contains(f.InstanceId.Value))
+            .Include(f => f.Drops)
+                .ThenInclude(d => d.DropItem)
+                    .ThenInclude(di => di.DropType)
+            .ToListAsync();
+
+        var result = instances.Select(i =>
+        {
+            var f = fights.Where(x => x.InstanceId == i.Id).ToList();
+            int gold = f.Sum(x => x.Gold);
+            int exp = f.Sum(x => x.Exp);
+            int psycho = f.Sum(x => x.Psycho);
+            int drop = f.SelectMany(x => x.Drops).Sum(FightsController.GetDropValueStatic);
+            return new InstanceDto
+            {
+                id = i.Id,
+                startTime = i.StartTime,
+                name = i.Name,
+                difficulty = i.Difficulty,
+                gold = gold,
+                exp = exp,
+                psycho = psycho,
+                profit = gold + drop,
+                fights = f.Count,
+                durationSeconds = i.EndTime != null ? (int?)(i.EndTime.Value - i.StartTime).TotalSeconds : null
+            };
+        }).ToList();
+
+        return result;
+    }
+
+    public async Task<List<InstanceFightDto>> GetFightsAsync(int instanceId)
+    {
+        var instance = await _db.Instances.FindAsync(instanceId);
+        if (instance == null) return [];
+
+        var fights = await _db.Fights
+            .Include(f => f.Opponents).ThenInclude(o => o.OpponentType)
+            .Include(f => f.Drops).ThenInclude(d => d.DropItem).ThenInclude(di => di.DropType)
+            .Where(f => f.InstanceId == instanceId)
+            .OrderByDescending(f => f.Time)
+            .ToListAsync();
+
+        var result = fights.Select(f => new InstanceFightDto
+        {
+            id = f.PublicId,
+            offsetSeconds = (int)(f.Time - instance.StartTime).TotalSeconds,
+            exp = f.Exp,
+            gold = f.Gold,
+            psycho = f.Psycho,
+            dropValue = f.Drops.Sum(FightsController.GetDropValueStatic),
+            opponents = string.Join(", ",
+                f.Opponents
+                    .GroupBy(o => o.OpponentType.Name)
+                    .Select(g =>
+                    {
+                        int qty = g.Sum(o => o.Quantity);
+                        return qty > 1 ? $"{g.Key} ({qty})" : g.Key;
+                    })
+            ),
+            drops = string.Join(", ",
+                f.Drops
+                    .Where(d => d.DropItem != null && d.DropItem.DropType != null)
+                    .OrderBy(d => DropTypeOrder(d.DropItem.DropType.Type))
+                    .ThenBy(d => d.DropItem.Name)
+                    .Select(d =>
+                    {
+                        var quality = string.IsNullOrWhiteSpace(d.DropItem.Quality) ? "" : $"[{d.DropItem.Quality}]";
+                        var amount = d.Quantity > 1 ? $" ({d.Quantity})" : "";
+                        return $"{d.DropItem.Name}{quality}{amount}";
+                    })
+            )
+        }).ToList();
+
+        return result;
+    }
+
+    private static int DropTypeOrder(string type) => type.ToLower() switch
+    {
+        "rare" => 0,
+        "synergetic" => 1,
+        "drif" => 2,
+        "item" => 3,
+        "trash" => 4,
+        _ => 5
+    };
+}

--- a/WinFormsFrontend/WinFormsFrontend.csproj
+++ b/WinFormsFrontend/WinFormsFrontend.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <UseWindowsForms>true</UseWindowsForms>
+    <Nullable>enable</Nullable>
+    <RootNamespace>BrokenStatsFrontendWinForms</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\BrokenStatsBackend.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
- update WinForms frontend to use a backend service abstraction
- add implementations for HTTP and direct database access
- wire up DI in Program.cs and allow LOCAL_BACKEND environment variable
- reference the backend project from WinForms project

## Testing
- `dotnet build BrokenStatsBackend.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68592a3420b88329afd8beec1ff1251b