### PR TITLE
Fix build errors

### DIFF
--- a/BrokenStatsBackend.csproj
+++ b/BrokenStatsBackend.csproj
@@ -14,4 +14,9 @@
     <PackageReference Include="SharpPcap" Version="6.3.1" />
   </ItemGroup>
 
+  <!-- Exclude the WinForms frontend source files from this project -->
+  <ItemGroup>
+    <Compile Remove="WinFormsFrontend\**\*.cs" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
## Summary
- exclude WinForms front-end files from the backend project

## Testing
- `dotnet build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68592e591230832992ee2b98bd9934fc