### PR TITLE
Add GenerateAssemblyInfo flag

### DIFF
--- a/BrokenStatsBackend.csproj
+++ b/BrokenStatsBackend.csproj
@@ -5,6 +5,9 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <OutputType>Exe</OutputType>
+    <!-- Disable automatic assembly info generation to avoid conflicts when
+         building on environments that still have leftover WinForms files. -->
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <RootNamespace>BrokenStatsBackend</RootNamespace>
   </PropertyGroup>
 


### PR DESCRIPTION
## Summary
- avoid duplicate assembly attributes when building by disabling automatic assembly info generation

## Testing
- `Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.`

------
https://chatgpt.com/codex/tasks/task_e_685933138f3c8329b137fe5e78828146