### PR TITLE
Add shutdown button to frontend

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -9,6 +9,7 @@ using Microsoft.AspNetCore.Http;
 using System.Linq;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Hosting;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -70,6 +71,11 @@ app.MapGet("/dashboard", () => Results.File(Path.Combine(frontendPath, "dashboar
 // Stats page
 app.MapGet("/stats", () => Results.File(Path.Combine(frontendPath, "stats.html"), "text/html"));
 app.MapControllers();
+app.MapPost("/api/shutdown", (IHostApplicationLifetime life) =>
+{
+    life.StopApplication();
+    return Results.Ok();
+});
 
 var scopeFactory = app.Services.GetRequiredService<IServiceScopeFactory>();
 

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -20,6 +20,7 @@
     <button id="backBtn" class="back-button" style="display:none;">Powrót</button>
     <button id="createBtn" class="end-button" style="display:none;">Stwórz instancję</button>
     <button id="deleteBtn" class="end-button" style="display:none;">Usuń instancję</button>
+    <button id="shutdownBtn" class="end-button">Zamknij aplikację</button>
   </div>
   <div id="listSummary" class="summary-widget"></div>
   <div id="instances"></div>
@@ -38,6 +39,7 @@ const statsBtn=document.getElementById('statsBtn');
 const backBtn=document.getElementById('backBtn');
 const createBtn=document.getElementById('createBtn');
 const deleteBtn=document.getElementById('deleteBtn');
+const shutdownBtn=document.getElementById('shutdownBtn');
 const instancesDiv=document.getElementById('instances');
 const detailsDiv=document.getElementById('details');
 const summaryDiv=document.getElementById('detailSummary');
@@ -341,6 +343,9 @@ deleteBtn.addEventListener('click',async ()=>{
   await fetch(`/api/instances/${id}`,{method:'DELETE'});
   backBtn.click();
   loadInstances();
+});
+shutdownBtn.addEventListener('click',()=>{
+  fetch('/api/shutdown',{method:'POST'});
 });
 });
 </script>


### PR DESCRIPTION
## Summary
- add `/api/shutdown` endpoint that stops the server
- add "Zamknij aplikację" button on dashboard calling the new API

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859349138d483298ffad4abe8de9eb9