### PR TITLE
Add frontend auto open and shutdown tab

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Hosting;
+using System.Diagnostics;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -75,6 +76,23 @@ app.MapPost("/api/shutdown", (IHostApplicationLifetime life) =>
 {
     life.StopApplication();
     return Results.Ok();
+});
+
+app.Lifetime.ApplicationStarted.Register(() =>
+{
+    try
+    {
+        Process.Start(new ProcessStartInfo
+        {
+            FileName = "http://localhost:5005",
+            UseShellExecute = true
+        });
+    }
+    catch (Exception ex)
+    {
+        var logger = app.Services.GetRequiredService<ILogger<Program>>();
+        logger.LogError(ex, "Failed to open browser");
+    }
 });
 
 var scopeFactory = app.Services.GetRequiredService<IServiceScopeFactory>();

--- a/README.md
+++ b/README.md
@@ -10,8 +10,7 @@ Start the API with:
 dotnet run
 ```
 
-It listens on `http://localhost:5005`.
-Open that URL in a browser to view the dashboard.
+It listens on `http://localhost:5005` and automatically opens the dashboard in your default browser.
 
 ## Environment
 

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -345,7 +345,9 @@ deleteBtn.addEventListener('click',async ()=>{
   loadInstances();
 });
 shutdownBtn.addEventListener('click',()=>{
-  fetch('/api/shutdown',{method:'POST'});
+  fetch('/api/shutdown',{method:'POST'}).then(()=>{
+    window.close();
+  });
 });
 });
 </script>


### PR DESCRIPTION
## Summary
- update README to mention automatic browser opening
- auto-launch frontend when starting the backend
- close browser tab on shutdown

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859372b07e483299dd6233b6430ed36