### PR TITLE
Add sidebar navigation and new fight view

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -71,6 +71,8 @@ app.UseStaticFiles(new StaticFileOptions { FileProvider = new PhysicalFileProvid
 app.MapGet("/dashboard", () => Results.File(Path.Combine(frontendPath, "dashboard.html"), "text/html"));
 // Stats page
 app.MapGet("/stats", () => Results.File(Path.Combine(frontendPath, "stats.html"), "text/html"));
+// Fights without instance page
+app.MapGet("/without", () => Results.File(Path.Combine(frontendPath, "without.html"), "text/html"));
 app.MapControllers();
 app.MapPost("/api/shutdown", (IHostApplicationLifetime life) =>
 {

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -63,6 +63,30 @@ let selectedNone=new Set();
 let currentInstanceId=null;
 let summaryMode=false;
 
+function downloadTableAsCSV(table, filename){
+  const rows=Array.from(table.querySelectorAll('tr')).map(tr=>
+    Array.from(tr.querySelectorAll('th,td')).map(td=>{
+      let text=td.innerText.replace(/\n/g,' ').trim();
+      text=text.replace(/"/g,'""');
+      return text.includes(',')||text.includes('"')?`"${text}"`:text;
+    }).join(',')
+  ).join('\n');
+  const blob=new Blob([rows],{type:'text/csv;charset=utf-8;'});
+  const a=document.createElement('a');
+  a.href=URL.createObjectURL(blob);
+  a.download=filename;
+  a.click();
+  URL.revokeObjectURL(a.href);
+}
+
+function createCsvButton(table, filename){
+  const btn=document.createElement('button');
+  btn.textContent='Pobierz CSV';
+  btn.className='csv-button';
+  btn.addEventListener('click',()=>downloadTableAsCSV(table, filename));
+  return btn;
+}
+
 function updateNoneSelection(row, selected){
   if(selected){
     selectedNone.add(row.dataset.id);
@@ -164,6 +188,7 @@ async function showInstances(list){
   });
   table.appendChild(tbody);
   instancesDiv.appendChild(table);
+  instancesDiv.appendChild(createCsvButton(table,'instancje.csv'));
   const selectAllCb=table.querySelector('#selectAll');
   tbody.querySelectorAll('button.close').forEach(btn=>btn.addEventListener('click',e=>{e.stopPropagation();closeInstance(btn.dataset.id);}));
   tbody.querySelectorAll('tr').forEach(tr=>tr.addEventListener('click',e=>{if(e.target.tagName==='BUTTON'||e.target.type==='checkbox')return;showDetails(tr.dataset.id);}));
@@ -208,6 +233,7 @@ function showDetails(id){
     table.appendChild(tbody);
     fightsDiv.innerHTML='';
     fightsDiv.appendChild(table);
+    fightsDiv.appendChild(createCsvButton(table,'walki.csv'));
     if(id==='none'){
       selectedNone=new Set();
       enableDragSelection(tbody);

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -5,24 +5,33 @@
   <title>Dashboard</title>
   <link rel="stylesheet" href="style.css">
   <style>
-    body{display:flex;flex-direction:column;align-items:center;gap:20px;}
     .controls{display:flex;gap:10px;margin-bottom:10px;justify-content:center;align-items:center;}
     .sticky-controls{position:sticky;top:0;z-index:100;background-color:#121212;padding:10px;width:100%;}
     #details{width:100%;}
   </style>
 </head>
-<body>
-  <div class="controls sticky-controls">
-    <label id="startLabel">Start: <input type="datetime-local" id="start"></label>
-    <label id="endLabel">Koniec: <input type="datetime-local" id="end"></label>
-    <button id="todayBtn" class="back-button">Dzisiaj</button>
-    <button id="statsBtn" class="back-button">Statystyki</button>
-    <button id="backBtn" class="back-button" style="display:none;">Powrót</button>
-    <button id="createBtn" class="end-button" style="display:none;">Stwórz instancję</button>
-    <button id="deleteBtn" class="end-button" style="display:none;">Usuń instancję</button>
-    <button id="shutdownBtn" class="end-button">Zamknij aplikację</button>
+<body class="with-sidebar">
+  <div class="sidebar" id="sidebar">
+    <button class="toggle" id="sidebarToggle">☰</button>
+    <ul>
+      <li><a href="dashboard.html"><span>Lista Instancji</span></a></li>
+      <li><a href="stats.html"><span>Statystyki instancji</span></a></li>
+      <li><a href="without.html"><span>Walki bez instancji</span></a></li>
+      <li><button id="sidebarShutdown"><span>Zamknij aplikację</span></button></li>
+    </ul>
   </div>
-  <div id="listSummary" class="summary-widget"></div>
+  <div class="content">
+    <div class="controls sticky-controls">
+      <label id="startLabel">Start: <input type="datetime-local" id="start"></label>
+      <label id="endLabel">Koniec: <input type="datetime-local" id="end"></label>
+      <button id="todayBtn" class="back-button">Dzisiaj</button>
+      <button id="prevDayBtn" class="back-button">&lt;</button>
+      <button id="nextDayBtn" class="back-button">&gt;</button>
+      <button id="summaryBtn" class="back-button">Podsumowanie</button>
+      <button id="backBtn" class="back-button" style="display:none;">Powrót</button>
+      <button id="createBtn" class="end-button" style="display:none;">Stwórz instancję</button>
+      <button id="deleteBtn" class="end-button" style="display:none;">Usuń instancję</button>
+    </div>
   <div id="instances"></div>
   <div id="details" style="display:none;">
     <div id="detailSummary" class="summary-widget"></div>
@@ -35,21 +44,24 @@ const endInput=document.getElementById('end');
 const startLabel=document.getElementById('startLabel');
 const endLabel=document.getElementById('endLabel');
 const todayBtn=document.getElementById('todayBtn');
-const statsBtn=document.getElementById('statsBtn');
+const prevDayBtn=document.getElementById('prevDayBtn');
+const nextDayBtn=document.getElementById('nextDayBtn');
+const summaryBtn=document.getElementById('summaryBtn');
 const backBtn=document.getElementById('backBtn');
 const createBtn=document.getElementById('createBtn');
 const deleteBtn=document.getElementById('deleteBtn');
-const shutdownBtn=document.getElementById('shutdownBtn');
+const sidebarToggle=document.getElementById('sidebarToggle');
+const sidebarShutdown=document.getElementById('sidebarShutdown');
 const instancesDiv=document.getElementById('instances');
 const detailsDiv=document.getElementById('details');
 const summaryDiv=document.getElementById('detailSummary');
-const listSummary=document.getElementById('listSummary');
 const fightsDiv=document.getElementById('fights');
 let instanceStarts={};
 const selectedInstances=new Set();
 const fightCache={};
 let selectedNone=new Set();
 let currentInstanceId=null;
+let summaryMode=false;
 
 function updateNoneSelection(row, selected){
   if(selected){
@@ -100,8 +112,8 @@ function enableDragSelection(tbody){
 }
 
 function updateHeaderButtons(){
-  if(currentInstanceId==='none'){
-    createBtn.style.display='inline-block';
+  if(summaryMode){
+    createBtn.style.display='none';
     deleteBtn.style.display='none';
   } else if(currentInstanceId){
     createBtn.style.display='none';
@@ -124,36 +136,16 @@ function aggregate(list){
 }
 async function loadFights(id){
   if(fightCache[id]) return fightCache[id];
-  if(id==='none'){return fightCache['none'];}
   const res=await fetch(`/api/instances/${id}/fights`);const data=await res.json();fightCache[id]=data;return data;
-}
-async function updateListSummary(){
-  if(selectedInstances.size===0){
-    if(detailsDiv.style.display==='block'){
-      listSummary.innerHTML='';
-    } else {
-      listSummary.innerHTML='<div class="no-fights-card"><p class="no-fights-text">Nic nie zaznaczono.</p></div>';
-    }
-    return;
-  }
-  const ids=[];
-  for(const id of selectedInstances){const fights=await loadFights(id);ids.push(...fights.map(f=>f.id));}
-  const res=await fetch('/api/fights/summary',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(ids)});const s=await res.json();
-  renderSummaryTo(listSummary,s);
 }
 async function loadInstances(){
   const from=startInput.value;const to=endInput.value;
   if(!from||!to)return;
-  const [inst, none] = await Promise.all([
-    fetch(`/api/instances/range?from=${encodeURIComponent(from)}&to=${encodeURIComponent(to)}`).then(r=>r.json()),
-    fetch(`/api/instances/without/fights?from=${encodeURIComponent(from)}&to=${encodeURIComponent(to)}`).then(r=>r.json())
-  ]);
-  fightCache['none']=none;
-  showInstances(inst, none);
+  const inst = await fetch(`/api/instances/range?from=${encodeURIComponent(from)}&to=${encodeURIComponent(to)}`).then(r=>r.json());
+  showInstances(inst);
 }
-async function showInstances(list, noneFights){
+async function showInstances(list){
   list.sort((a,b)=>new Date(b.startTime)-new Date(a.startTime));
-  noneFights.sort((a,b)=>new Date(b.time)-new Date(a.time));
   selectedInstances.clear();
   instancesDiv.innerHTML='';
   instanceStarts={};
@@ -161,14 +153,6 @@ async function showInstances(list, noneFights){
   table.className='custom-dark-table';
   table.innerHTML=`<thead><tr><th><input type="checkbox" id="selectAll"></th><th>Data startu</th><th>Nazwa</th><th>Trudność</th><th>Złoto</th><th>Exp</th><th>Psycho</th><th>Zarobek</th><th>Walki</th><th>Czas trwania</th></tr></thead>`;
   const tbody=document.createElement('tbody');
-  if(noneFights.length>0){
-    const agg=aggregate(noneFights);
-    instanceStarts['none']=agg.start;
-    const tr=document.createElement('tr');
-    tr.dataset.id='none';
-    tr.innerHTML=`<td><input type="checkbox" data-id="none"></td><td>${formatDate(new Date(agg.start))}</td><td>Bez instancji</td><td></td><td>${agg.gold.toLocaleString()}</td><td>${agg.exp.toLocaleString()}</td><td>${agg.psycho.toLocaleString()}</td><td>${agg.profit.toLocaleString()}</td><td>${agg.count}</td><td>${formatDuration(agg.duration)}</td>`;
-    tbody.appendChild(tr);
-  }
   list.forEach(inst=>{
     instanceStarts[inst.id]=inst.startTime;
     const diff=inst.difficulty===3?'Trudna':inst.difficulty===1?'Normalna':'Łatwa';
@@ -186,7 +170,6 @@ async function showInstances(list, noneFights){
   tbody.querySelectorAll('input[type="checkbox"]').forEach(cb=>cb.addEventListener('change',async ()=>{
     updateInstanceSelection(cb.closest('tr'), cb.checked);
     selectAllCb.checked=[...tbody.querySelectorAll('input[type="checkbox"]')].every(x=>x.checked);
-    await updateListSummary();
   }));
   selectAllCb.addEventListener('change',async ()=>{
     const state=selectAllCb.checked;
@@ -194,7 +177,6 @@ async function showInstances(list, noneFights){
       cb.checked=state;
       updateInstanceSelection(cb.closest('tr'), state);
     });
-    await updateListSummary();
   });
 }
 function closeInstance(id){
@@ -235,10 +217,9 @@ function showDetails(id){
     startLabel.style.display='none';
     endLabel.style.display='none';
     todayBtn.style.display='none';
-    backBtn.style.display='inline-block';
-    currentInstanceId=id;
-    updateHeaderButtons();
-    updateListSummary();
+  backBtn.style.display='inline-block';
+  currentInstanceId=id;
+  updateHeaderButtons();
   });
 }
 function renderSummaryTo(el,s){
@@ -254,10 +235,12 @@ backBtn.addEventListener('click',()=>{
   startLabel.style.display='inline-block';
   endLabel.style.display='inline-block';
   todayBtn.style.display='inline-block';
+  prevDayBtn.style.display='inline-block';
+  nextDayBtn.style.display='inline-block';
   backBtn.style.display='none';
   currentInstanceId=null;
+  summaryMode=false;
   updateHeaderButtons();
-  updateListSummary();
 });
 function toInputValue(dt){
   const off=dt.getTimezoneOffset();
@@ -294,9 +277,6 @@ todayBtn.addEventListener('click',()=>{
   setDefaultRange();
   saveRange();
   loadInstances();
-});
-statsBtn.addEventListener('click',()=>{
-  window.location.href='stats.html';
 });
 
 function openCreateInstanceModal(){
@@ -340,14 +320,42 @@ createBtn.addEventListener('click',openCreateInstanceModal);
 deleteBtn.addEventListener('click',async ()=>{
   const id=deleteBtn.dataset.id;
   if(!id) return;
+  if(!confirm('Usunąć instancję?')) return;
   await fetch(`/api/instances/${id}`,{method:'DELETE'});
   backBtn.click();
   loadInstances();
 });
-shutdownBtn.addEventListener('click',()=>{
+sidebarShutdown.addEventListener('click',()=>{
   fetch('/api/shutdown',{method:'POST'}).then(()=>{
     window.close();
   });
+});
+sidebarToggle.addEventListener('click',()=>{
+  document.getElementById('sidebar').classList.toggle('collapsed');
+});
+prevDayBtn.addEventListener('click',()=>{
+  const s=new Date(startInput.value);const e=new Date(endInput.value);s.setDate(s.getDate()-1);e.setDate(e.getDate()-1);startInput.value=toInputValue(s);endInput.value=toInputValue(e);saveRange();loadInstances();
+});
+nextDayBtn.addEventListener('click',()=>{
+  const s=new Date(startInput.value);const e=new Date(endInput.value);s.setDate(s.getDate()+1);e.setDate(e.getDate()+1);startInput.value=toInputValue(s);endInput.value=toInputValue(e);saveRange();loadInstances();
+});
+summaryBtn.addEventListener('click',async ()=>{
+  if(selectedInstances.size===0){alert('Nic nie zaznaczono');return;}
+  const ids=[];for(const id of selectedInstances){const fights=await loadFights(id);ids.push(...fights.map(f=>f.id));}
+  const res=await fetch('/api/fights/summary',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(ids)});const s=await res.json();
+  renderSummaryTo(summaryDiv,s);
+  fightsDiv.innerHTML='';
+  instancesDiv.style.display='none';
+  detailsDiv.style.display='block';
+  startLabel.style.display='none';
+  endLabel.style.display='none';
+  todayBtn.style.display='none';
+  prevDayBtn.style.display='none';
+  nextDayBtn.style.display='none';
+  backBtn.style.display='inline-block';
+  summaryMode=true;
+  currentInstanceId=null;
+  updateHeaderButtons();
 });
 });
 </script>
@@ -382,6 +390,7 @@ shutdownBtn.addEventListener('click',()=>{
       <button type="button" id="cancelCreateInstance" class="btn btn-secondary">Anuluj</button>
     </div>
   </div>
+</div>
 </div>
 </body>
 </html>

--- a/frontend/stats.html
+++ b/frontend/stats.html
@@ -27,10 +27,32 @@
   </div>
 <script>
 document.addEventListener('DOMContentLoaded',()=>{
-  const sidebarToggle=document.getElementById('sidebarToggle');
-  const sidebarShutdown=document.getElementById('sidebarShutdown');
-  sidebarToggle.addEventListener('click',()=>{document.getElementById('sidebar').classList.toggle('collapsed');});
-  sidebarShutdown.addEventListener('click',()=>{fetch('/api/shutdown',{method:'POST'}).then(()=>{window.close();});});
+  const sidebarToggle = document.getElementById('sidebarToggle');
+  const sidebarShutdown = document.getElementById('sidebarShutdown');
+  sidebarToggle.addEventListener('click', () => { document.getElementById('sidebar').classList.toggle('collapsed'); });
+  sidebarShutdown.addEventListener('click', () => { fetch('/api/shutdown', { method: 'POST' }).then(() => { window.close(); }); });
+  function downloadTableAsCSV(table, filename) {
+    const rows = Array.from(table.querySelectorAll('tr')).map(tr =>
+      Array.from(tr.querySelectorAll('th,td')).map(td => {
+        let text = td.innerText.replace(/\n/g, ' ').trim();
+        text = text.replace(/"/g, '""');
+        return text.includes(',') || text.includes('"') ? `"${text}"` : text;
+      }).join(',')
+    ).join('\n');
+    const blob = new Blob([rows], { type: 'text/csv;charset=utf-8;' });
+    const a = document.createElement('a');
+    a.href = URL.createObjectURL(blob);
+    a.download = filename;
+    a.click();
+    URL.revokeObjectURL(a.href);
+  }
+  function createCsvButton(table, filename) {
+    const btn = document.createElement('button');
+    btn.textContent = 'Pobierz CSV';
+    btn.className = 'csv-button';
+    btn.addEventListener('click', () => downloadTableAsCSV(table, filename));
+    return btn;
+  }
   document.getElementById('backDashboardBtn').addEventListener('click',()=>{
     window.location.href='dashboard.html';
   });
@@ -47,7 +69,9 @@ document.addEventListener('DOMContentLoaded',()=>{
       tbody.appendChild(tr);
     });
     table.appendChild(tbody);
-    document.getElementById('statsTableContainer').appendChild(table);
+    const container=document.getElementById('statsTableContainer');
+    container.appendChild(table);
+    container.appendChild(createCsvButton(table,'statystyki.csv'));
   }
 });
 </script>

--- a/frontend/stats.html
+++ b/frontend/stats.html
@@ -5,18 +5,32 @@
   <title>Statystyki Instancji</title>
   <link rel="stylesheet" href="style.css">
   <style>
-    body{display:flex;flex-direction:column;align-items:center;gap:20px;}
     .controls{display:flex;gap:10px;margin-bottom:10px;justify-content:center;align-items:center;}
     .sticky-controls{position:sticky;top:0;z-index:100;background-color:#121212;padding:10px;width:100%;}
   </style>
 </head>
-<body>
-  <div class="controls sticky-controls">
-    <button id="backDashboardBtn" class="back-button">Powrót</button>
+<body class="with-sidebar">
+  <div class="sidebar" id="sidebar">
+    <button class="toggle" id="sidebarToggle">☰</button>
+    <ul>
+      <li><a href="dashboard.html"><span>Lista Instancji</span></a></li>
+      <li><a href="stats.html"><span>Statystyki instancji</span></a></li>
+      <li><a href="without.html"><span>Walki bez instancji</span></a></li>
+      <li><button id="sidebarShutdown"><span>Zamknij aplikację</span></button></li>
+    </ul>
   </div>
-  <div id="statsTableContainer" style="width:100%;"></div>
+  <div class="content">
+    <div class="controls sticky-controls">
+      <button id="backDashboardBtn" class="back-button">Powrót</button>
+    </div>
+    <div id="statsTableContainer" style="width:100%;"></div>
+  </div>
 <script>
 document.addEventListener('DOMContentLoaded',()=>{
+  const sidebarToggle=document.getElementById('sidebarToggle');
+  const sidebarShutdown=document.getElementById('sidebarShutdown');
+  sidebarToggle.addEventListener('click',()=>{document.getElementById('sidebar').classList.toggle('collapsed');});
+  sidebarShutdown.addEventListener('click',()=>{fetch('/api/shutdown',{method:'POST'}).then(()=>{window.close();});});
   document.getElementById('backDashboardBtn').addEventListener('click',()=>{
     window.location.href='dashboard.html';
   });

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -449,3 +449,56 @@ h1 {
 .datetime-row .form-group {
   flex: 1;
 }
+/* Sidebar */
+.sidebar {
+  width: 220px;
+  background-color: #1e1e1e;
+  padding: 10px;
+  transition: width 0.3s;
+  display: flex;
+  flex-direction: column;
+}
+.sidebar.collapsed {
+  width: 40px;
+}
+.sidebar button.toggle {
+  background-color: #333;
+  color: #eee;
+  border: none;
+  padding: 8px;
+  cursor: pointer;
+  margin-bottom: 10px;
+}
+.sidebar ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+.sidebar li {
+  padding: 8px;
+}
+.sidebar li:hover {
+  background-color: #2e2e2e;
+}
+.sidebar li a,
+.sidebar li button {
+  color: #eee;
+  text-decoration: none;
+  display: block;
+  width: 100%;
+  text-align: left;
+  background: none;
+  border: none;
+  cursor: pointer;
+}
+.sidebar.collapsed li span {
+  display: none;
+}
+.content {
+  flex: 1;
+  padding: 20px;
+}
+body.with-sidebar {
+  display: flex;
+  min-height: 100vh;
+}

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -338,6 +338,17 @@ h1 {
   min-width: 120px;
   text-align: center;
 }
+.csv-button {
+  background-color: #333;
+  color: #eee;
+  padding: 8px 16px;
+  border: none;
+  border-radius: 5px;
+  cursor: pointer;
+  margin-bottom: 20px;
+  min-width: 120px;
+  text-align: center;
+}
 #backBtn {
   margin-right: auto;
 }

--- a/frontend/without.html
+++ b/frontend/without.html
@@ -54,6 +54,30 @@ const detailsDiv=document.getElementById('details');
 let fights=[];
 const selected=new Set();
 
+function downloadTableAsCSV(table, filename){
+  const rows=Array.from(table.querySelectorAll('tr')).map(tr=>
+    Array.from(tr.querySelectorAll('th,td')).map(td=>{
+      let text=td.innerText.replace(/\n/g,' ').trim();
+      text=text.replace(/"/g,'""');
+      return text.includes(',')||text.includes('"')?`"${text}"`:text;
+    }).join(',')
+  ).join('\n');
+  const blob=new Blob([rows],{type:'text/csv;charset=utf-8;'});
+  const a=document.createElement('a');
+  a.href=URL.createObjectURL(blob);
+  a.download=filename;
+  a.click();
+  URL.revokeObjectURL(a.href);
+}
+
+function createCsvButton(table, filename){
+  const btn=document.createElement('button');
+  btn.textContent='Pobierz CSV';
+  btn.className='csv-button';
+  btn.addEventListener('click',()=>downloadTableAsCSV(table, filename));
+  return btn;
+}
+
 function updateSelection(row,sel){
   if(sel){selected.add(row.dataset.id);row.classList.add('selected');}
   else{selected.delete(row.dataset.id);row.classList.remove('selected');}
@@ -85,7 +109,11 @@ async function loadFights(){
   const table=document.createElement('table');table.className='custom-dark-table';table.innerHTML=`<thead><tr><th>Data</th><th>Złoto</th><th>Exp</th><th>Psycho</th><th>Przeciwnicy</th><th>Drop</th></tr></thead>`;
   const tbody=document.createElement('tbody');
   fights.forEach(f=>{const tr=document.createElement('tr');tr.dataset.id=f.id;tr.innerHTML=`<td>${formatDate(new Date(f.time))}</td><td>${f.gold}</td><td>${f.exp}</td><td>${f.psycho}</td><td>${f.opponents}</td><td>${f.drops}</td>`;tbody.appendChild(tr);});
-  table.appendChild(tbody);fightsDiv.innerHTML='';fightsDiv.appendChild(table);enableDragSelection(tbody);
+  table.appendChild(tbody);
+  fightsDiv.innerHTML='';
+  fightsDiv.appendChild(table);
+  fightsDiv.appendChild(createCsvButton(table,'walki.csv'));
+  enableDragSelection(tbody);
 }
 function saveRange(){localStorage.setItem('startTime',startInput.value);localStorage.setItem('endTime',endInput.value);}
 startInput.addEventListener('change',()=>{saveRange();loadFights();});

--- a/frontend/without.html
+++ b/frontend/without.html
@@ -1,0 +1,169 @@
+<!DOCTYPE html>
+<html lang="pl">
+<head>
+  <meta charset="UTF-8">
+  <title>Walki bez instancji</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    .controls{display:flex;gap:10px;margin-bottom:10px;justify-content:center;align-items:center;}
+    .sticky-controls{position:sticky;top:0;z-index:100;background-color:#121212;padding:10px;width:100%;}
+    #details{width:100%;}
+  </style>
+</head>
+<body class="with-sidebar">
+  <div class="sidebar" id="sidebar">
+    <button class="toggle" id="sidebarToggle">☰</button>
+    <ul>
+      <li><a href="dashboard.html"><span>Lista Instancji</span></a></li>
+      <li><a href="stats.html"><span>Statystyki instancji</span></a></li>
+      <li><a href="without.html"><span>Walki bez instancji</span></a></li>
+      <li><button id="sidebarShutdown"><span>Zamknij aplikację</span></button></li>
+    </ul>
+  </div>
+  <div class="content">
+    <div class="controls sticky-controls">
+      <label id="startLabel">Start: <input type="datetime-local" id="start"></label>
+      <label id="endLabel">Koniec: <input type="datetime-local" id="end"></label>
+      <button id="todayBtn" class="back-button">Dzisiaj</button>
+      <button id="prevDayBtn" class="back-button">&lt;</button>
+      <button id="nextDayBtn" class="back-button">&gt;</button>
+      <button id="summaryBtn" class="back-button">Podsumowanie</button>
+      <button id="createBtn" class="end-button">Stwórz instancję</button>
+      <button id="backBtn" class="back-button" style="display:none;">Powrót</button>
+    </div>
+    <div id="details" style="display:none;">
+      <div id="detailSummary" class="summary-widget"></div>
+    </div>
+    <div id="fights"></div>
+  </div>
+<script>
+document.addEventListener('DOMContentLoaded',()=>{
+const startInput=document.getElementById('start');
+const endInput=document.getElementById('end');
+const todayBtn=document.getElementById('todayBtn');
+const prevDayBtn=document.getElementById('prevDayBtn');
+const nextDayBtn=document.getElementById('nextDayBtn');
+const summaryBtn=document.getElementById('summaryBtn');
+const backBtn=document.getElementById('backBtn');
+const createBtn=document.getElementById('createBtn');
+const sidebarToggle=document.getElementById('sidebarToggle');
+const sidebarShutdown=document.getElementById('sidebarShutdown');
+const fightsDiv=document.getElementById('fights');
+const summaryDiv=document.getElementById('detailSummary');
+const detailsDiv=document.getElementById('details');
+let fights=[];
+const selected=new Set();
+
+function updateSelection(row,sel){
+  if(sel){selected.add(row.dataset.id);row.classList.add('selected');}
+  else{selected.delete(row.dataset.id);row.classList.remove('selected');}
+}
+function enableDragSelection(tbody){
+  const rows=Array.from(tbody.querySelectorAll('tr'));
+  let dragging=false;let dragState=true;let startIndex=null;
+  tbody.addEventListener('mousedown',e=>{const tr=e.target.closest('tr');if(!tr)return;e.preventDefault();dragging=true;startIndex=rows.indexOf(tr);dragState=!tr.classList.contains('selected');updateSelection(tr,dragState);});
+  tbody.addEventListener('mouseover',e=>{if(!dragging)return;const tr=e.target.closest('tr');if(!tr)return;const endIndex=rows.indexOf(tr);const [min,max]=startIndex<endIndex?[startIndex,endIndex]:[endIndex,startIndex];rows.forEach((r,i)=>{if(i>=min&&i<=max)updateSelection(r,dragState);});});
+  document.addEventListener('mouseup',()=>{dragging=false;});
+}
+function pad(n){return n.toString().padStart(2,'0');}
+function formatDate(dt){return `${pad(dt.getDate())}.${pad(dt.getMonth()+1)} ${pad(dt.getHours())}:${pad(dt.getMinutes())}:${pad(dt.getSeconds())}`;}
+function formatDuration(sec){const h=Math.floor(sec/3600);const m=Math.floor((sec%3600)/60);const s=sec%60;return `${pad(h)}:${pad(m)}:${pad(s)}`;}
+function renderSummaryTo(el,s){
+  const card=(t,v)=>`<div class="card"><h3>${t}</h3><div class="value">${v}</div></div>`;
+  const drops=l=>l.map(d=>`<div class="line-item"><span class="label">${d.name}</span><span class="value">${d.count.toLocaleString()}</span></div>`).join('');
+  const dropVals={};Object.entries(s.dropValuesPerType).forEach(([k,v])=>dropVals[k.toLowerCase()]=v);
+  const dropCard=(t,l,v)=>`<div class="card"><h3>${t}</h3>${drops(l)}<div class="total-value">= ${v.toLocaleString()}</div></div>`;
+  el.innerHTML=`<div class="stats-row">${card('Exp',s.totalExp.toLocaleString())}${card('Psycho',s.totalPsycho.toLocaleString())}${card('Złoto',s.totalGold.toLocaleString())}${card('Zarobek',s.totalGoldWithDrops.toLocaleString())}${card('Walki',s.fightsCount.toLocaleString())}${card('Czas',formatDuration(Math.floor((new Date(s.sessionEnd)-new Date(s.sessionStart))/1000)))}</div><div class="drops-grid">${dropCard('Rary',s.rare,dropVals['rare']||0)}${dropCard('Użytkowe',s.items,dropVals['item']||0)}${dropCard('Białe',s.trash,dropVals['trash']||0)}${dropCard('Syngi',s.synergetics,dropVals['synergetic']||0)}${dropCard('Drify',s.drifs,dropVals['drif']||0)}${dropCard('Orby',[],0)}</div>`;
+}
+function toInputValue(dt){const off=dt.getTimezoneOffset();return new Date(dt.getTime()-off*60000).toISOString().slice(0,16);}
+function setDefaultRange(){const now=new Date();const s=new Date(now.getFullYear(),now.getMonth(),now.getDate(),0,0,0);const e=new Date(now.getFullYear(),now.getMonth(),now.getDate(),23,59,59);startInput.value=toInputValue(s);endInput.value=toInputValue(e);}
+async function loadFights(){
+  const from=startInput.value;const to=endInput.value;if(!from||!to)return;
+  fights=await fetch(`/api/instances/without/fights?from=${encodeURIComponent(from)}&to=${encodeURIComponent(to)}`).then(r=>r.json());
+  fights.sort((a,b)=>new Date(b.time)-new Date(a.time));
+  selected.clear();
+  const table=document.createElement('table');table.className='custom-dark-table';table.innerHTML=`<thead><tr><th>Data</th><th>Złoto</th><th>Exp</th><th>Psycho</th><th>Przeciwnicy</th><th>Drop</th></tr></thead>`;
+  const tbody=document.createElement('tbody');
+  fights.forEach(f=>{const tr=document.createElement('tr');tr.dataset.id=f.id;tr.innerHTML=`<td>${formatDate(new Date(f.time))}</td><td>${f.gold}</td><td>${f.exp}</td><td>${f.psycho}</td><td>${f.opponents}</td><td>${f.drops}</td>`;tbody.appendChild(tr);});
+  table.appendChild(tbody);fightsDiv.innerHTML='';fightsDiv.appendChild(table);enableDragSelection(tbody);
+}
+function saveRange(){localStorage.setItem('startTime',startInput.value);localStorage.setItem('endTime',endInput.value);}
+startInput.addEventListener('change',()=>{saveRange();loadFights();});
+endInput.addEventListener('change',()=>{saveRange();loadFights();});
+todayBtn.addEventListener('click',()=>{setDefaultRange();saveRange();loadFights();});
+prevDayBtn.addEventListener('click',()=>{const s=new Date(startInput.value);const e=new Date(endInput.value);s.setDate(s.getDate()-1);e.setDate(e.getDate()-1);startInput.value=toInputValue(s);endInput.value=toInputValue(e);saveRange();loadFights();});
+nextDayBtn.addEventListener('click',()=>{const s=new Date(startInput.value);const e=new Date(endInput.value);s.setDate(s.getDate()+1);e.setDate(e.getDate()+1);startInput.value=toInputValue(s);endInput.value=toInputValue(e);saveRange();loadFights();});
+sidebarToggle.addEventListener('click',()=>{document.getElementById('sidebar').classList.toggle('collapsed');});
+sidebarShutdown.addEventListener('click',()=>{fetch('/api/shutdown',{method:'POST'}).then(()=>{window.close();});});
+summaryBtn.addEventListener('click',async ()=>{
+  if(selected.size===0){alert('Nic nie zaznaczono');return;}
+  const ids=Array.from(selected);
+  const res=await fetch('/api/fights/summary',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(ids)});const s=await res.json();
+  renderSummaryTo(summaryDiv,s);
+  detailsDiv.style.display='block';
+  fightsDiv.style.display='none';
+  backBtn.style.display='inline-block';
+});
+backBtn.addEventListener('click',()=>{detailsDiv.style.display='none';fightsDiv.style.display='block';backBtn.style.display='none';});
+createBtn.addEventListener('click',()=>{
+  if(selected.size===0){alert('Zaznacz walki do utworzenia instancji.');return;}
+  const times=Array.from(selected).map(id=>new Date(fights.find(x=>x.id===id).time));
+  const s=new Date(Math.min(...times)-15000);
+  const e=new Date(Math.max(...times));
+  document.getElementById('instanceStart').value=s.toISOString().slice(0,16);
+  document.getElementById('instanceEnd').value=e.toISOString().slice(0,16);
+  document.getElementById('createInstanceModal').classList.add('show');
+});
+document.getElementById('confirmCreateInstance').addEventListener('click',async ()=>{
+  const name=document.getElementById('instanceName').value;
+  const difficulty=parseInt(document.getElementById('instanceDifficulty').value);
+  const start=document.getElementById('instanceStart').value;
+  const end=document.getElementById('instanceEnd').value;
+  const res=await fetch('/api/instances',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({name,difficulty,startTime:start,endTime:end,fightIds:Array.from(selected)})});
+  if(!res.ok){const msg=await res.text();alert(msg);return;}
+  document.getElementById('createInstanceModal').classList.remove('show');
+  loadFights();
+});
+document.getElementById('closeCreateInstanceModal').addEventListener('click',()=>{document.getElementById('createInstanceModal').classList.remove('show');});
+document.getElementById('cancelCreateInstance').addEventListener('click',()=>{document.getElementById('createInstanceModal').classList.remove('show');});
+
+const savedStart=localStorage.getItem('startTime');
+const savedEnd=localStorage.getItem('endTime');
+if(savedStart&&savedEnd){startInput.value=savedStart;endInput.value=savedEnd;}else{setDefaultRange();}
+loadFights();
+});
+</script>
+<div class="modal" id="createInstanceModal" tabindex="-1">
+  <div class="form-card">
+    <button type="button" id="closeCreateInstanceModal" class="btn-close" aria-label="Close" style="align-self:flex-end;"></button>
+    <h2 class="form-title">Utwórz instancję</h2>
+    <div class="form-group">
+      <label class="form-label" for="instanceName">Nazwa</label>
+      <input type="text" id="instanceName" class="form-control" placeholder="Np. Hvar, Torisa...">
+    </div>
+    <div class="form-group">
+      <label class="form-label" for="instanceDifficulty">Poziom trudności</label>
+      <select id="instanceDifficulty" class="form-select">
+        <option value="1">Normalny</option>
+        <option value="2">Łatwy</option>
+        <option value="3">Trudny</option>
+      </select>
+    </div>
+    <div class="datetime-row">
+      <div class="form-group">
+        <label class="form-label" for="instanceStart">Start</label>
+        <input type="datetime-local" id="instanceStart" class="form-control">
+      </div>
+      <div class="form-group">
+        <label class="form-label" for="instanceEnd">Koniec</label>
+        <input type="datetime-local" id="instanceEnd" class="form-control">
+      </div>
+    </div>
+    <div class="button-row" style="margin-top: 16px;">
+      <button type="button" id="confirmCreateInstance" class="btn btn-primary">Zapisz</button>
+      <button type="button" id="cancelCreateInstance" class="btn btn-secondary">Anuluj</button>
+    </div>
+  </div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add sidebar layout and styling
- update dashboard with date navigation and summary button
- integrate sidebar into stats page
- create page for fights without instances
- map new page in backend

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68593c1cb9f48329bc09c9908be77812