### PR TITLE
Adjust sidebar and header layout

### DIFF
--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -2,11 +2,60 @@
 <html lang="pl">
 <head>
   <meta charset="UTF-8">
-  <title>Dashboard</title>
+  <title>Broken Stats</title>
   <link rel="stylesheet" href="style.css">
   <style>
-    .controls{display:flex;gap:10px;margin-bottom:10px;justify-content:center;align-items:center;}
-    .sticky-controls{position:sticky;top:0;z-index:100;background-color:#121212;padding:10px;width:100%;}
+    .controls {
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+    }
+    .sticky-controls {
+      position: sticky;
+      top: 0;
+      z-index: 100;
+      background-color: #121212;
+      padding: 10px;
+      width: 100%;
+    }
+    .controls-top-row,
+    .controls-bottom-row {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      justify-content: space-between;
+    }
+    .left-controls {
+      flex: 1;
+      display: flex;
+      align-items: center;
+    }
+    .right-controls {
+      flex: 1;
+      display: flex;
+      justify-content: flex-end;
+      gap: 10px;
+    }
+    .controls-bottom-row {
+      gap: 10px;
+      flex-wrap: wrap;
+      justify-content: flex-start;
+    }
+    .controls-bottom-row label {
+      display: flex;
+      align-items: center;
+      color: #ccc;
+      font-size: 13px;
+      gap: 6px;
+    }
+    .controls-bottom-row input[type="datetime-local"] {
+      background-color: #2a2a2a;
+      color: #eee;
+      border: 1px solid #444;
+      padding: 4px 8px;
+      border-radius: 4px;
+      font-size: 13px;
+    }
     #details{width:100%;}
   </style>
 </head>
@@ -22,16 +71,27 @@
   </div>
   <div class="content">
     <div class="controls sticky-controls">
-      <label id="startLabel">Start: <input type="datetime-local" id="start"></label>
-      <label id="endLabel">Koniec: <input type="datetime-local" id="end"></label>
-
-      <button id="todayBtn" class="button standard-button">Dzisiaj</button>
-      <button id="prevDayBtn" class="button nav-button">&lt;</button>
-      <button id="nextDayBtn" class="button nav-button">&gt;</button>
-      <button id="summaryBtn" class="button standard-button">Podsumowanie</button>
-      <button id="createBtn" class="button primary-button" style="display:none;">Stwórz instancję</button>
-      <button id="backBtn" class="button standard-button" style="display:none;">Powrót</button>
-      <button id="deleteBtn" class="end-button" style="display:none;">Usuń instancję</button>
+      <div class="controls-top-row">
+        <div class="left-controls">
+          <button id="backBtn" class="button standard-button" style="display:none;">Powrót</button>
+        </div>
+        <div class="right-controls">
+          <button id="summaryBtn" class="button standard-button">Podsumowanie</button>
+          <button id="createBtn" class="button primary-button" style="display:none;">Stwórz instancję</button>
+          <button id="deleteBtn" class="end-button" style="display:none;">Usuń instancję</button>
+        </div>
+      </div>
+      <div class="controls-bottom-row">
+        <button id="todayBtn" class="button standard-button">Dzisiaj</button>
+        <label id="startLabel">Start:
+          <input type="datetime-local" id="start">
+        </label>
+        <label id="endLabel">Koniec:
+          <input type="datetime-local" id="end">
+        </label>
+        <button id="prevDayBtn" class="button nav-button">&lt;</button>
+        <button id="nextDayBtn" class="button nav-button">&gt;</button>
+      </div>
     </div>
   <div id="instances"></div>
   <div id="details" style="display:none;">

--- a/frontend/stats.html
+++ b/frontend/stats.html
@@ -2,7 +2,7 @@
 <html lang="pl">
 <head>
   <meta charset="UTF-8">
-  <title>Statystyki Instancji</title>
+  <title>Broken Stats</title>
   <link rel="stylesheet" href="style.css">
   <style>
     .controls{display:flex;gap:10px;margin-bottom:10px;justify-content:center;align-items:center;}

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -510,7 +510,7 @@ h1 {
   display: flex;
   flex-direction: column;
   position: fixed;
-  right: 0;
+  left: 0;
   top: 0;
   bottom: 0;
   height: 100vh;
@@ -558,5 +558,4 @@ h1 {
 body.with-sidebar {
   display: block;
   min-height: 100vh;
-  margin-right: 300px;
 }

--- a/frontend/without.html
+++ b/frontend/without.html
@@ -2,11 +2,60 @@
 <html lang="pl">
 <head>
   <meta charset="UTF-8">
-  <title>Walki bez instancji</title>
+  <title>Broken Stats</title>
   <link rel="stylesheet" href="style.css">
   <style>
-    .controls{display:flex;gap:10px;margin-bottom:10px;justify-content:center;align-items:center;}
-    .sticky-controls{position:sticky;top:0;z-index:100;background-color:#121212;padding:10px;width:100%;}
+    .controls {
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+    }
+    .sticky-controls {
+      position: sticky;
+      top: 0;
+      z-index: 100;
+      background-color: #121212;
+      padding: 10px;
+      width: 100%;
+    }
+    .controls-top-row,
+    .controls-bottom-row {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      justify-content: space-between;
+    }
+    .left-controls {
+      flex: 1;
+      display: flex;
+      align-items: center;
+    }
+    .right-controls {
+      flex: 1;
+      display: flex;
+      justify-content: flex-end;
+      gap: 10px;
+    }
+    .controls-bottom-row {
+      gap: 10px;
+      flex-wrap: wrap;
+      justify-content: flex-start;
+    }
+    .controls-bottom-row label {
+      display: flex;
+      align-items: center;
+      color: #ccc;
+      font-size: 13px;
+      gap: 6px;
+    }
+    .controls-bottom-row input[type="datetime-local"] {
+      background-color: #2a2a2a;
+      color: #eee;
+      border: 1px solid #444;
+      padding: 4px 8px;
+      border-radius: 4px;
+      font-size: 13px;
+    }
     #details{width:100%;}
   </style>
 </head>
@@ -22,15 +71,26 @@
   </div>
   <div class="content">
     <div class="controls sticky-controls">
-      <label id="startLabel">Start: <input type="datetime-local" id="start"></label>
-      <label id="endLabel">Koniec: <input type="datetime-local" id="end"></label>
-
-      <button id="todayBtn" class="button standard-button">Dzisiaj</button>
-      <button id="prevDayBtn" class="button nav-button">&lt;</button>
-      <button id="nextDayBtn" class="button nav-button">&gt;</button>
-      <button id="summaryBtn" class="button standard-button">Podsumowanie</button>
-      <button id="createBtn" class="button primary-button">Stwórz instancję</button>
-      <button id="backBtn" class="button standard-button" style="display:none;">Powrót</button>
+      <div class="controls-top-row">
+        <div class="left-controls">
+          <button id="backBtn" class="button standard-button" style="display:none;">Powrót</button>
+        </div>
+        <div class="right-controls">
+          <button id="summaryBtn" class="button standard-button">Podsumowanie</button>
+          <button id="createBtn" class="button primary-button">Stwórz instancję</button>
+        </div>
+      </div>
+      <div class="controls-bottom-row">
+        <button id="todayBtn" class="button standard-button">Dzisiaj</button>
+        <label id="startLabel">Start:
+          <input type="datetime-local" id="start">
+        </label>
+        <label id="endLabel">Koniec:
+          <input type="datetime-local" id="end">
+        </label>
+        <button id="prevDayBtn" class="button nav-button">&lt;</button>
+        <button id="nextDayBtn" class="button nav-button">&gt;</button>
+      </div>
     </div>
     <div id="details" style="display:none;">
       <div id="detailSummary" class="summary-widget"></div>


### PR DESCRIPTION
## Summary
- move sidebar to the left and remove body offset
- update titles to "Broken Stats"
- apply two-row header layout for dashboard and without pages

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859482eede08329a1c77d093381a607