### PR TITLE
Add page titles and shutdown confirmation

### DIFF
--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -70,6 +70,7 @@
     </ul>
   </div>
   <div class="content">
+    <h1>Lista Instancji</h1>
     <div class="controls sticky-controls">
       <div class="controls-top-row">
         <div class="left-controls">
@@ -418,9 +419,11 @@ deleteBtn.addEventListener('click',async ()=>{
   loadInstances();
 });
 sidebarShutdown.addEventListener('click',()=>{
-  fetch('/api/shutdown',{method:'POST'}).then(()=>{
-    window.close();
-  });
+  if(confirm('Czy na pewno chcesz zamknąć aplikację?')){
+    fetch('/api/shutdown',{method:'POST'}).then(()=>{
+      window.close();
+    });
+  }
 });
 sidebarToggle.addEventListener('click',()=>{
   document.getElementById('sidebar').classList.toggle('collapsed');

--- a/frontend/stats.html
+++ b/frontend/stats.html
@@ -20,9 +20,7 @@
     </ul>
   </div>
   <div class="content">
-    <div class="controls sticky-controls">
-      <button id="backDashboardBtn" class="button standard-button">Powrót</button>
-    </div>
+    <h1>Statystyki instancji</h1>
     <div id="statsTableContainer" style="width:100%;"></div>
   </div>
 <script>
@@ -30,7 +28,13 @@ document.addEventListener('DOMContentLoaded',()=>{
   const sidebarToggle = document.getElementById('sidebarToggle');
   const sidebarShutdown = document.getElementById('sidebarShutdown');
   sidebarToggle.addEventListener('click', () => { document.getElementById('sidebar').classList.toggle('collapsed'); });
-  sidebarShutdown.addEventListener('click', () => { fetch('/api/shutdown', { method: 'POST' }).then(() => { window.close(); }); });
+  sidebarShutdown.addEventListener('click', () => {
+    if(confirm('Czy na pewno chcesz zamknąć aplikację?')){
+      fetch('/api/shutdown', { method: 'POST' }).then(() => {
+        window.close();
+      });
+    }
+  });
   function downloadTableAsCSV(table, filename) {
     const rows = Array.from(table.querySelectorAll('tr')).map(tr =>
       Array.from(tr.querySelectorAll('th,td')).map(td => {
@@ -53,9 +57,6 @@ document.addEventListener('DOMContentLoaded',()=>{
     btn.addEventListener('click', () => downloadTableAsCSV(table, filename));
     return btn;
   }
-  document.getElementById('backDashboardBtn').addEventListener('click',()=>{
-    window.location.href='dashboard.html';
-  });
   fetch('/api/instances/stats').then(r=>r.json()).then(showStats);
   function showStats(list){
     const table=document.createElement('table');

--- a/frontend/without.html
+++ b/frontend/without.html
@@ -70,6 +70,7 @@
     </ul>
   </div>
   <div class="content">
+    <h1>Walki bez instancji</h1>
     <div class="controls sticky-controls">
       <div class="controls-top-row">
         <div class="left-controls">
@@ -183,7 +184,11 @@ todayBtn.addEventListener('click',()=>{setDefaultRange();saveRange();loadFights(
 prevDayBtn.addEventListener('click',()=>{const s=new Date(startInput.value);const e=new Date(endInput.value);s.setDate(s.getDate()-1);e.setDate(e.getDate()-1);startInput.value=toInputValue(s);endInput.value=toInputValue(e);saveRange();loadFights();});
 nextDayBtn.addEventListener('click',()=>{const s=new Date(startInput.value);const e=new Date(endInput.value);s.setDate(s.getDate()+1);e.setDate(e.getDate()+1);startInput.value=toInputValue(s);endInput.value=toInputValue(e);saveRange();loadFights();});
 sidebarToggle.addEventListener('click',()=>{document.getElementById('sidebar').classList.toggle('collapsed');});
-sidebarShutdown.addEventListener('click',()=>{fetch('/api/shutdown',{method:'POST'}).then(()=>{window.close();});});
+sidebarShutdown.addEventListener('click',()=>{
+  if(confirm('Czy na pewno chcesz zamknąć aplikację?')){
+    fetch('/api/shutdown',{method:'POST'}).then(()=>{window.close();});
+  }
+});
 summaryBtn.addEventListener('click',async ()=>{
   if(selected.size===0){alert('Nic nie zaznaczono');return;}
   const ids=Array.from(selected);


### PR DESCRIPTION
## Summary
- show clear `<h1>` headers on the dashboard, stats and fights pages
- confirm shutdown before closing the app
- remove unused back button from the stats page

## Testing
- `dotnet build BrokenStatsBackend.sln` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68594dbea3bc8329b34c47c87d5f5a04