### PR TITLE
Fix header button alignment

### DIFF
--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -23,17 +23,19 @@
       display: flex;
       flex-wrap: wrap;
       align-items: center;
-      justify-content: space-between;
+    }
+    .controls-top-row {
+      justify-content: center;
+      position: relative;
     }
     .left-controls {
-      flex: 1;
+      position: absolute;
+      left: 0;
       display: flex;
       align-items: center;
     }
     .right-controls {
-      flex: 1;
       display: flex;
-      justify-content: flex-end;
       gap: 10px;
     }
     .controls-bottom-row {

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -404,7 +404,7 @@ h1 {
   text-align: center;
 }
 #backBtn {
-  margin-right: auto;
+  margin-right: 0;
 }
 
 .end-button {

--- a/frontend/without.html
+++ b/frontend/without.html
@@ -23,17 +23,19 @@
       display: flex;
       flex-wrap: wrap;
       align-items: center;
-      justify-content: space-between;
+    }
+    .controls-top-row {
+      justify-content: center;
+      position: relative;
     }
     .left-controls {
-      flex: 1;
+      position: absolute;
+      left: 0;
       display: flex;
       align-items: center;
     }
     .right-controls {
-      flex: 1;
       display: flex;
-      justify-content: flex-end;
       gap: 10px;
     }
     .controls-bottom-row {


### PR DESCRIPTION
## Summary
- center header buttons on instance list and fights pages
- keep the back button on the left

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685961187f688329a071ec89cba67793