### PR TITLE
Add fights list and break management

### DIFF
--- a/frontend/breaks.html
+++ b/frontend/breaks.html
@@ -1,0 +1,120 @@
+<!DOCTYPE html>
+<html lang="pl">
+<head>
+  <meta charset="UTF-8">
+  <title>Zapisane przerwy</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body class="with-sidebar">
+  <div class="sidebar" id="sidebar">
+    <button class="toggle" id="sidebarToggle">☰</button>
+    <ul>
+      <li><a href="dashboard.html"><span>Lista Instancji</span></a></li>
+      <li><a href="stats.html"><span>Statystyki instancji</span></a></li>
+      <li><a href="fights.html"><span>Lista Walk</span></a></li>
+      <li><a href="without.html"><span>Walki bez instancji</span></a></li>
+      <li><a href="breaks.html"><span>Zapisane przerwy</span></a></li>
+    </ul>
+    <button id="sidebarShutdown"><span>Zamknij aplikację</span></button>
+  </div>
+  <div class="content">
+    <h1>Zapisane przerwy</h1>
+    <div class="controls sticky-controls">
+      <div class="controls-top-row">
+        <button id="addBtn" class="button primary-button">Dodaj przerwę</button>
+        <button id="editBtn" class="button standard-button" style="display:none;">Edytuj</button>
+        <button id="delBtn" class="end-button" style="display:none;">Usuń</button>
+      </div>
+    </div>
+    <div id="breaksTable"></div>
+  </div>
+<script>
+document.addEventListener('DOMContentLoaded',()=>{
+  const sidebarToggle=document.getElementById('sidebarToggle');
+  const sidebarShutdown=document.getElementById('sidebarShutdown');
+  const addBtn=document.getElementById('addBtn');
+  const editBtn=document.getElementById('editBtn');
+  const delBtn=document.getElementById('delBtn');
+  const tableDiv=document.getElementById('breaksTable');
+  let breaks=[];
+  let selectedId=null;
+
+  sidebarToggle.addEventListener('click',()=>document.getElementById('sidebar').classList.toggle('collapsed'));
+  sidebarShutdown.addEventListener('click',()=>{if(confirm('Czy na pewno chcesz zamknąć aplikację?')){fetch('/api/shutdown',{method:'POST'}).then(()=>window.close());}});
+
+  function updateButtons(){
+    editBtn.style.display=selectedId? 'inline-block':'none';
+    delBtn.style.display=selectedId? 'inline-block':'none';
+  }
+
+  async function load(){
+    breaks=await fetch('/api/breaks').then(r=>r.json());
+    breaks.sort((a,b)=>new Date(b.startTime)-new Date(a.startTime));
+    const table=document.createElement('table');
+    table.className='custom-dark-table';
+    table.innerHTML=`<thead><tr><th>Start</th><th>Koniec</th><th>Instancja</th></tr></thead>`;
+    const tbody=document.createElement('tbody');
+    breaks.forEach(b=>{
+      const tr=document.createElement('tr');
+      tr.dataset.id=b.id;
+      tr.innerHTML=`<td class="nowrap">${new Date(b.startTime).toLocaleString()}</td><td class="nowrap">${new Date(b.endTime).toLocaleString()}</td><td>${b.instance||'brak'}</td>`;
+      tbody.appendChild(tr);
+    });
+    table.appendChild(tbody);
+    tableDiv.innerHTML='';
+    tableDiv.appendChild(table);
+    tbody.querySelectorAll('tr').forEach(tr=>tr.addEventListener('click',()=>{
+      if(selectedId===tr.dataset.id){tr.classList.remove('selected');selectedId=null;}else{tbody.querySelectorAll('tr').forEach(r=>r.classList.remove('selected'));tr.classList.add('selected');selectedId=tr.dataset.id;}updateButtons();}));
+    updateButtons();
+  }
+
+  function openModal(b){
+    document.getElementById('breakStart').value=b?b.startTime.slice(0,16):new Date().toISOString().slice(0,16);
+    document.getElementById('breakEnd').value=b?b.endTime.slice(0,16):new Date().toISOString().slice(0,16);
+    document.getElementById('breakModal').dataset.id=b?b.id:'';
+    document.getElementById('breakModal').classList.add('show');
+  }
+
+  addBtn.addEventListener('click',()=>openModal(null));
+  editBtn.addEventListener('click',()=>{
+    const b=breaks.find(x=>x.id==selectedId);if(b)openModal({id:b.id,startTime:b.startTime,endTime:b.endTime});
+  });
+  delBtn.addEventListener('click',async ()=>{if(!selectedId)return;if(!confirm('Usunąć?'))return;await fetch(`/api/breaks/${selectedId}`,{method:'DELETE'});selectedId=null;load();});
+
+  document.getElementById('confirmBreak').addEventListener('click',async ()=>{
+    const id=document.getElementById('breakModal').dataset.id;
+    const start=document.getElementById('breakStart').value;
+    const end=document.getElementById('breakEnd').value;
+    if(id){await fetch(`/api/breaks/${id}`,{method:'PUT',headers:{'Content-Type':'application/json'},body:JSON.stringify({startTime:start,endTime:end})});}
+    else{await fetch('/api/breaks',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({startTime:start,endTime:end})});}
+    document.getElementById('breakModal').classList.remove('show');
+    load();
+  });
+  document.getElementById('cancelBreak').addEventListener('click',()=>document.getElementById('breakModal').classList.remove('show'));
+  document.getElementById('closeBreakModal').addEventListener('click',()=>document.getElementById('breakModal').classList.remove('show'));
+
+  load();
+});
+</script>
+<div class="modal" id="breakModal" tabindex="-1">
+  <div class="form-card">
+    <button type="button" id="closeBreakModal" class="btn-close" aria-label="Close" style="align-self:flex-end;"></button>
+    <h2 class="form-title">Przerwa</h2>
+    <div class="datetime-row">
+      <div class="form-group">
+        <label class="form-label" for="breakStart">Start</label>
+        <input type="datetime-local" id="breakStart" class="form-control">
+      </div>
+      <div class="form-group">
+        <label class="form-label" for="breakEnd">Koniec</label>
+        <input type="datetime-local" id="breakEnd" class="form-control">
+      </div>
+    </div>
+    <div class="button-row" style="margin-top: 16px;">
+      <button type="button" id="confirmBreak" class="btn btn-primary">Zapisz</button>
+      <button type="button" id="cancelBreak" class="btn btn-secondary">Anuluj</button>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -67,7 +67,9 @@
     <ul>
       <li><a href="dashboard.html"><span>Lista Instancji</span></a></li>
       <li><a href="stats.html"><span>Statystyki instancji</span></a></li>
+      <li><a href="fights.html"><span>Lista Walk</span></a></li>
       <li><a href="without.html"><span>Walki bez instancji</span></a></li>
+      <li><a href="breaks.html"><span>Zapisane przerwy</span></a></li>
     </ul>
     <button id="sidebarShutdown"><span>Zamknij aplikację</span></button>
   </div>

--- a/frontend/fights.html
+++ b/frontend/fights.html
@@ -2,7 +2,7 @@
 <html lang="pl">
 <head>
   <meta charset="UTF-8">
-  <title>Broken Stats</title>
+  <title>Lista Walk</title>
   <link rel="stylesheet" href="style.css">
   <style>
     .controls {
@@ -74,7 +74,7 @@
     <button id="sidebarShutdown"><span>Zamknij aplikację</span></button>
   </div>
   <div class="content">
-    <h1>Walki bez instancji</h1>
+    <h1>Lista Walk</h1>
     <div class="controls sticky-controls">
       <div class="controls-top-row">
         <div class="left-controls">
@@ -169,17 +169,30 @@ function toInputValue(dt){const off=dt.getTimezoneOffset();return new Date(dt.ge
 function setDefaultRange(){const now=new Date();const s=new Date(now.getFullYear(),now.getMonth(),now.getDate(),0,0,0);const e=new Date(now.getFullYear(),now.getMonth(),now.getDate(),23,59,59);startInput.value=toInputValue(s);endInput.value=toInputValue(e);}
 async function loadFights(){
   const from=startInput.value;const to=endInput.value;if(!from||!to)return;
-  fights=await fetch(`/api/instances/without/fights?from=${encodeURIComponent(from)}&to=${encodeURIComponent(to)}`).then(r=>r.json());
+  fights=await fetch(`/api/fights/flat?startDateTime=${encodeURIComponent(from)}&endDateTime=${encodeURIComponent(to)}`).then(r=>r.json());
   fights.sort((a,b)=>new Date(b.time)-new Date(a.time));
   selected.clear();
-  const table=document.createElement('table');table.className='custom-dark-table';table.innerHTML=`<thead><tr><th class="nowrap">Data</th><th>Złoto</th><th>Exp</th><th>Psycho</th><th>Przeciwnicy</th><th>Drop</th></tr></thead>`;
+  const table=document.createElement('table');table.className='custom-dark-table';table.innerHTML=`<thead><tr><th class="nowrap">Data</th><th>Złoto</th><th>Exp</th><th>Psycho</th><th>Instancja</th><th>Przeciwnicy</th><th>Drop</th></tr></thead>`;
   const tbody=document.createElement('tbody');
-  fights.forEach(f=>{const tr=document.createElement('tr');tr.dataset.id=f.id;tr.innerHTML=`<td class="nowrap">${formatDate(new Date(f.time))}</td><td>${f.gold}</td><td>${f.exp}</td><td>${f.psycho}</td><td class="truncate" title="${f.opponents}">${f.opponents}</td><td class="truncate" title="${f.drops}">${f.drops}</td>`;tbody.appendChild(tr);});
+  fights.forEach(f=>{const tr=document.createElement('tr');tr.dataset.id=f.id;tr.dataset.instance=f.instanceId||'';tr.innerHTML=`<td class="nowrap">${formatDate(new Date(f.time))}</td><td>${f.gold}</td><td>${f.exp}</td><td>${f.psycho}</td><td>${f.instanceName||''}</td><td class="truncate" title="${f.opponents}">${f.opponents}</td><td class="truncate" title="${f.drops}">${f.drops}</td>`;tbody.appendChild(tr);});
   table.appendChild(tbody);
   fightsDiv.innerHTML='';
   fightsDiv.appendChild(table);
   fightsDiv.appendChild(createCsvButton(table,'walki.csv'));
   enableDragSelection(tbody);
+  tbody.querySelectorAll('tr').forEach(tr=>tr.addEventListener('click',async e=>{
+    if(e.target.tagName==='INPUT')return;
+    const instId=tr.dataset.instance;
+    if(!instId)return;
+    const data=await fetch(`/api/instances/${instId}/fights`).then(r=>r.json());
+    const ids=data.map(f=>f.id);
+    const summary=await fetch('/api/fights/summary',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(ids)}).then(r=>r.json());
+    renderSummaryTo(summaryDiv,summary);
+    detailsDiv.style.display='block';
+    fightsDiv.style.display='none';
+    backBtn.style.display='inline-block';
+    summaryBtn.style.display='none';
+  }));
 }
 function saveRange(){localStorage.setItem('startTime',startInput.value);localStorage.setItem('endTime',endInput.value);}
 startInput.addEventListener('change',()=>{saveRange();loadFights();});

--- a/frontend/stats.html
+++ b/frontend/stats.html
@@ -15,7 +15,9 @@
     <ul>
       <li><a href="dashboard.html"><span>Lista Instancji</span></a></li>
       <li><a href="stats.html"><span>Statystyki instancji</span></a></li>
+      <li><a href="fights.html"><span>Lista Walk</span></a></li>
       <li><a href="without.html"><span>Walki bez instancji</span></a></li>
+      <li><a href="breaks.html"><span>Zapisane przerwy</span></a></li>
     </ul>
     <button id="sidebarShutdown"><span>Zamknij aplikację</span></button>
   </div>

--- a/src/Controllers/BreaksController.cs
+++ b/src/Controllers/BreaksController.cs
@@ -11,6 +11,21 @@ public class BreaksController(AppDbContext db) : ControllerBase
 {
     private readonly AppDbContext _db = db;
 
+    [HttpGet]
+    public async Task<IActionResult> GetBreaks()
+    {
+        var breaks = await _db.Breaks.OrderByDescending(b => b.StartTime).ToListAsync();
+        var instances = await _db.Instances.ToListAsync();
+        var result = breaks.Select(b => new
+        {
+            id = b.Id,
+            startTime = b.StartTime,
+            endTime = b.EndTime,
+            instance = instances.FirstOrDefault(i => i.StartTime <= b.StartTime && (i.EndTime ?? DateTime.MaxValue) >= b.EndTime)?.Name
+        });
+        return Ok(result);
+    }
+
     [HttpPost]
     public async Task<IActionResult> CreateBreak([FromBody] CreateBreakDto dto)
     {
@@ -22,5 +37,26 @@ public class BreaksController(AppDbContext db) : ControllerBase
         _db.Breaks.Add(entity);
         await _db.SaveChangesAsync();
         return Ok(new { id = entity.Id });
+    }
+
+    [HttpPut("{id}")]
+    public async Task<IActionResult> UpdateBreak(int id, [FromBody] CreateBreakDto dto)
+    {
+        var entity = await _db.Breaks.FindAsync(id);
+        if (entity == null) return NotFound();
+        entity.StartTime = dto.StartTime;
+        entity.EndTime = dto.EndTime;
+        await _db.SaveChangesAsync();
+        return Ok();
+    }
+
+    [HttpDelete("{id}")]
+    public async Task<IActionResult> DeleteBreak(int id)
+    {
+        var entity = await _db.Breaks.FindAsync(id);
+        if (entity == null) return NotFound();
+        _db.Breaks.Remove(entity);
+        await _db.SaveChangesAsync();
+        return Ok();
     }
 }

--- a/src/Controllers/InstancesController.cs
+++ b/src/Controllers/InstancesController.cs
@@ -285,6 +285,19 @@ public class InstancesController(AppDbContext db, ILogger<InstancesController> l
 
     }
 
+    [HttpPut("{id}")]
+    public async Task<IActionResult> UpdateInstance(int id, [FromBody] CreateInstanceDto dto)
+    {
+        var instance = await _db.Instances.FindAsync(id);
+        if (instance == null) return NotFound();
+        instance.Name = dto.Name;
+        instance.Difficulty = dto.Difficulty;
+        instance.StartTime = dto.StartTime;
+        instance.EndTime = dto.EndTime;
+        await _db.SaveChangesAsync();
+        return Ok();
+    }
+
     [HttpPost("closeLast")]
     public async Task<IActionResult> CloseLastInstance()
     {

--- a/src/Models/FightFlatDto.cs
+++ b/src/Models/FightFlatDto.cs
@@ -10,5 +10,7 @@ namespace BrokenStatsBackend.src.Models
         public int DropValue { get; set; }
         public string Opponents { get; set; } = string.Empty;
         public string Drops { get; set; } = string.Empty;
+        public string? InstanceName { get; set; }
+        public int? InstanceId { get; set; }
     }
 }

--- a/src/Models/UpdateFightDto.cs
+++ b/src/Models/UpdateFightDto.cs
@@ -1,0 +1,10 @@
+namespace BrokenStatsBackend.src.Models;
+
+public class UpdateFightDto
+{
+    public DateTime Time { get; set; }
+    public int Gold { get; set; }
+    public int Psycho { get; set; }
+    public int Exp { get; set; }
+    public int? InstanceId { get; set; }
+}


### PR DESCRIPTION
## Summary
- extend FightFlatDto with instance info
- add CRUD actions for breaks
- add instance update API
- allow updating/deleting fights
- show fight list with filtering and summary
- list and edit breaks via new page
- link new pages in sidebar

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a7221c0608329ac1907f5fd4edbcf